### PR TITLE
Add glow effect for claim inspection

### DIFF
--- a/bukkit/src/main/java/net/william278/huskclaims/BukkitHuskClaims.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/BukkitHuskClaims.java
@@ -269,6 +269,18 @@ public class BukkitHuskClaims extends JavaPlugin implements HuskClaims, BukkitTa
         ));
     }
 
+    @Override
+    public void sendBlockUpdates(@NotNull OnlineUser user, @NotNull List<Position> positions) {
+        final Player player = ((BukkitUser) user).getBukkitPlayer();
+        positions.forEach(position -> {
+            Location location = Adapter.adapt(position);
+            player.sendBlockChange(
+                    location,
+                    Objects.requireNonNull(location.getWorld()).getBlockAt(location).getBlockData()
+            );
+        });
+    }
+
     public static class Adapter {
         @NotNull
         public static Position adapt(@NotNull Location location) {

--- a/common/src/main/java/net/william278/huskclaims/config/Locales.java
+++ b/common/src/main/java/net/william278/huskclaims/config/Locales.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 /**
  * Plugin locale configuration
@@ -54,7 +55,7 @@ public class Locales implements PaginatedListProvider {
     protected static final String DEFAULT_LOCALE = "en-gb";
 
     // The raw set of locales loaded from yaml
-    private Map<String, String> locales = Maps.newLinkedHashMap();
+    private Map<String, String> locales = new TreeMap<>();
 
     /**
      * Returns a raw, unformatted locale loaded from the locales file

--- a/common/src/main/java/net/william278/huskclaims/config/Settings.java
+++ b/common/src/main/java/net/william278/huskclaims/config/Settings.java
@@ -32,9 +32,7 @@ import net.william278.huskclaims.network.Broker;
 import net.william278.huskclaims.position.World;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @SuppressWarnings("FieldMayBeFinal")
 @Getter
@@ -76,7 +74,7 @@ public final class Settings {
         PoolOptions poolOptions;
 
         @Comment("Names of tables to use on your database. Don't modify this unless you know what you're doing!")
-        Map<Database.Table, String> tableNames = Maps.newLinkedHashMap(Map.of(
+        Map<Database.Table, String> tableNames = new TreeMap<>(Map.of(
                 Database.Table.META_DATA, Database.Table.META_DATA.getDefaultName(),
                 Database.Table.USER_DATA, Database.Table.USER_DATA.getDefaultName(),
                 Database.Table.USER_GROUP_DATA, Database.Table.USER_GROUP_DATA.getDefaultName(),
@@ -215,7 +213,7 @@ public final class Settings {
         private int inspectionDistance = 40;
 
         @Comment("Blocks to use for the block highlighter")
-        private Map<Highlightable.HighlightType, String> blockHighlighterTypes = Maps.newLinkedHashMap(Map.of(
+        private Map<Highlightable.HighlightType, String> blockHighlighterTypes = new TreeMap<>(Map.of(
                 Highlightable.HighlightType.EDGE, "minecraft:gold_block",
                 Highlightable.HighlightType.CORNER, "minecraft:glowstone",
                 Highlightable.HighlightType.ADMIN_CORNER, "minecraft:jack_o_lantern",
@@ -226,6 +224,25 @@ public final class Settings {
                 Highlightable.HighlightType.OVERLAP_EDGE, "minecraft:netherrack",
                 Highlightable.HighlightType.SELECTION, "minecraft:diamond_block"
         ));
+
+
+        @Comment("Color of the glow effect for highlighted blocks. Works only on paper 1.19.4+. ")
+        private Map<Highlightable.HighlightType, Color> blockHighlighterColors = new TreeMap<>(Map.of(
+                Highlightable.HighlightType.EDGE, Color.YELLOW,
+                Highlightable.HighlightType.CORNER, Color.YELLOW,
+                Highlightable.HighlightType.ADMIN_CORNER, Color.ORANGE,
+                Highlightable.HighlightType.ADMIN_EDGE, Color.ORANGE,
+                Highlightable.HighlightType.CHILD_CORNER, Color.SILVER,
+                Highlightable.HighlightType.CHILD_EDGE, Color.SILVER,
+                Highlightable.HighlightType.OVERLAP_CORNER, Color.RED,
+                Highlightable.HighlightType.OVERLAP_EDGE, Color.RED,
+                Highlightable.HighlightType.SELECTION, Color.AQUA
+        ));
+
+        @NotNull
+        public Color getBlockHighlighterColor(@NotNull Highlightable.HighlightType highlightType) {
+            return Optional.ofNullable(blockHighlighterColors.get(highlightType)).orElse(Color.WHITE);
+        }
 
         public boolean isWorldUnclaimable(@NotNull World world) {
             return unclaimableWorlds.stream().anyMatch(world.getName()::equalsIgnoreCase);
@@ -282,6 +299,34 @@ public final class Settings {
 
         @Comment("Max groups per player")
         private int maxGroupsPerPlayer = 3;
+    }
+
+    @Getter
+    public enum Color {
+
+        WHITE(16777215),
+        SILVER(12632256),
+        GRAY(8421504),
+        BLACK(0),
+        RED(16711680),
+        MAROON(8388608),
+        YELLOW(16776960),
+        OLIVE(8421376),
+        LIME(65280),
+        GREEN(32768),
+        AQUA(65535),
+        TEAL(32896),
+        BLUE(255),
+        NAVY(128),
+        FUCHSIA(16711935),
+        PURPLE(8388736),
+        ORANGE(16753920);
+
+        private final int rgb;
+
+        Color(int rgb) {
+            this.rgb = rgb;
+        }
     }
 
 }

--- a/common/src/main/java/net/william278/huskclaims/position/Position.java
+++ b/common/src/main/java/net/william278/huskclaims/position/Position.java
@@ -86,4 +86,13 @@ public class Position implements BlockPosition, OperationPosition {
     public int getBlockZ() {
         return (int) getZ();
     }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Position position) {
+            return position.x == x && position.y == y && position.z == z && position.world.equals(world);
+        }
+        return false;
+    }
 }

--- a/common/src/main/java/net/william278/huskclaims/util/BlockProvider.java
+++ b/common/src/main/java/net/william278/huskclaims/util/BlockProvider.java
@@ -72,6 +72,15 @@ public interface BlockProvider {
     void sendBlockUpdates(@NotNull OnlineUser user, @NotNull Map<Position, MaterialBlock> blocks);
 
     /**
+     * Sends block updates to a specific online user based on the given positions.
+     *
+     * @param user      the online user to send the block updates to
+     * @param positions the list of positions to update blocks at
+     * @since 1.0
+     */
+    void sendBlockUpdates(@NotNull OnlineUser user, @NotNull List<Position> positions);
+
+    /**
      * Abstract representation of a block with material data
      */
     abstract class MaterialBlock {

--- a/paper/src/main/java/net/william278/huskclaims/PaperHuskClaims.java
+++ b/paper/src/main/java/net/william278/huskclaims/PaperHuskClaims.java
@@ -21,6 +21,8 @@ package net.william278.huskclaims;
 
 import lombok.NoArgsConstructor;
 import net.kyori.adventure.audience.Audience;
+import net.william278.huskclaims.highlighter.BlockHighlighter;
+import net.william278.huskclaims.highlighter.GlowHighlighter;
 import net.william278.huskclaims.position.Position;
 import net.william278.huskclaims.user.BukkitUser;
 import net.william278.huskclaims.user.OnlineUser;
@@ -44,6 +46,11 @@ public class PaperHuskClaims extends BukkitHuskClaims {
     public Audience getAudience(@NotNull UUID user) {
         final Player player = getServer().getPlayer(user);
         return player == null || !player.isOnline() ? Audience.empty() : player;
+    }
+
+    @Override
+    public void loadClaimHighlighter() {
+        setHighlighter(new GlowHighlighter(this));
     }
 
 }

--- a/paper/src/main/java/net/william278/huskclaims/highlighter/GlowHighlighter.java
+++ b/paper/src/main/java/net/william278/huskclaims/highlighter/GlowHighlighter.java
@@ -19,23 +19,175 @@
 
 package net.william278.huskclaims.highlighter;
 
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import net.william278.huskclaims.HuskClaims;
+import net.william278.huskclaims.PaperHuskClaims;
+import net.william278.huskclaims.claim.ClaimWorld;
+import net.william278.huskclaims.claim.Region;
+import net.william278.huskclaims.position.Position;
 import net.william278.huskclaims.position.World;
 import net.william278.huskclaims.user.OnlineUser;
+import net.william278.huskclaims.util.BlockDataBlock;
+import net.william278.huskclaims.util.BlockProvider;
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.BlockDisplay;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
-//todo
 public class GlowHighlighter implements Highlighter {
 
-    @Override
+    private final PaperHuskClaims plugin;
+    private final Multimap<UUID, HighlightedBlock> activeHighlights;
+
+    public GlowHighlighter(@NotNull HuskClaims plugin) {
+        this.plugin = (PaperHuskClaims) plugin;
+        this.activeHighlights = Multimaps.newListMultimap(
+                Maps.newConcurrentMap(), CopyOnWriteArrayList::new
+        );
+    }
+
+    /**
+     * Check if there are any duplicates in the given blocks based on the existing active highlights of the user.
+     *
+     * @param user   The online user
+     * @param blocks The map of positions to material blocks
+     * @return {@code true} if there are no duplicates, {@code false} if there are duplicates
+     */
+    private boolean checkDuplicate(@NotNull OnlineUser user, Map<Position, BlockProvider.MaterialBlock> blocks) {
+        final Collection<HighlightedBlock> existing = activeHighlights.get(user.getUuid());
+        if (existing.isEmpty()) {
+            return false;
+        }
+
+        return existing.stream().allMatch(e -> blocks.keySet().stream().anyMatch(e.position::equals));
+    }
+
     public void startHighlighting(@NotNull OnlineUser user, @NotNull World world,
                                   @NotNull Collection<? extends Highlightable> toHighlight, boolean showOverlap) {
 
+        plugin.runSync(() -> {
+            final Optional<ClaimWorld> optionalClaimWorld = plugin.getClaimWorld(world);
+            if (optionalClaimWorld.isEmpty()) {
+                return;
+            }
+
+            final ClaimWorld claimWorld = optionalClaimWorld.get();
+            final Set<HighlightedBlock> activeBlocks = Sets.newHashSet();
+            final Player player = Bukkit.getPlayer(user.getUuid());
+
+            if (player == null) {
+                return;
+            }
+
+            final Map<Position, BlockProvider.MaterialBlock> blocks = Maps.newHashMap();
+            final Map<Position, Highlightable> highlightPoints = Maps.newHashMap();
+            final Map<Position, BlockProvider.MaterialBlock> original = Maps.newHashMap();
+            final Map<Position, Highlightable.HighlightType> typeMap = Maps.newHashMap();
+
+            for (Highlightable highlight : toHighlight) {
+                final Map<Region.Point, Highlightable.HighlightType> type = highlight.getHighlightPoints(claimWorld, showOverlap);
+                plugin.getHighestBlocksAt(type.keySet(), world)
+                        .forEach((pos, material) -> {
+                            highlightPoints.put(pos, highlight);
+                            blocks.put(pos, highlight.getBlockFor(claimWorld, pos, plugin, showOverlap));
+                            original.put(pos, material);
+                            typeMap.put(pos, type.entrySet()
+                                    .stream()
+                                    .filter(e -> e.getKey().equals(Region.Point.wrap(pos)))
+                                    .map(Map.Entry::getValue)
+                                    .findFirst()
+                                    .orElse(Highlightable.HighlightType.SELECTION));
+                        });
+            }
+
+            if (checkDuplicate(user, blocks)) {
+                return;
+            }
+
+            stopHighlighting(user);
+
+            blocks.forEach((pos, material) -> {
+                activeBlocks.add(new HighlightedBlock(
+                        pos,
+                        highlightPoints.get(pos).getBlockFor(claimWorld, pos, plugin, showOverlap),
+                        original.get(pos),
+                        player, plugin, typeMap.get(pos)
+                ));
+            });
+
+            final BlockDataBlock barrier = new BlockDataBlock(Material.BARRIER.createBlockData());
+            final Set<Position> positions = blocks.keySet();
+
+            activeHighlights.putAll(user.getUuid(), activeBlocks);
+            plugin.sendBlockUpdates(user, positions.stream().collect(Collectors.toMap(p -> p, p -> barrier)));
+        });
     }
 
     @Override
     public void stopHighlighting(@NotNull OnlineUser user) {
+        final Collection<HighlightedBlock> blocks = activeHighlights.removeAll(user.getUuid());
+        plugin.sendBlockUpdates(user, blocks.stream().map(b -> b.position).toList());
+        blocks.stream().map(HighlightedBlock::getBlockDisplay).forEach(BlockDisplay::remove);
+    }
+
+
+    @Getter
+    @Accessors(fluent = true)
+    @NotNull
+    private static final class HighlightedBlock {
+        private final Position position;
+        private final BlockProvider.MaterialBlock originalBlock;
+        private final BlockProvider.MaterialBlock block;
+        private final UUID entityId;
+
+        public HighlightedBlock(@NotNull Position position, @NotNull BlockProvider.MaterialBlock block,
+                                @NotNull BlockProvider.MaterialBlock originalBlock,
+                                @NotNull Player player, @NotNull PaperHuskClaims plugin,
+                                @NotNull Highlightable.HighlightType type) {
+            this.position = position;
+            this.block = block;
+            this.originalBlock = originalBlock;
+            this.entityId = createEntity(player, plugin, type);
+        }
+
+        private UUID createEntity(@NotNull Player player, @NotNull PaperHuskClaims plugin, @NotNull Highlightable.HighlightType type) {
+            final org.bukkit.World world = Bukkit.getWorld(position.getWorld().getUuid());
+            if (world == null) {
+                throw new NullPointerException("World is null");
+            }
+
+            final Location location = new Location(world, position.getX(), position.getY(), position.getZ());
+            final BlockDataBlock block = (BlockDataBlock) this.block;
+            final BlockDisplay display = world.spawn(location, BlockDisplay.class);
+            display.setBlock(block.getData());
+            display.setGravity(false);
+            display.setGlowing(true);
+            display.setInvulnerable(true);
+            display.setSilent(true);
+            display.setPersistent(false);
+            display.setCustomNameVisible(false);
+            display.setVisibleByDefault(false);
+            display.setGlowColorOverride(Color.fromRGB(plugin.getSettings().getClaims().getBlockHighlighterColor(type).getRgb()));
+            player.showEntity(plugin, display);
+
+            return display.getUniqueId();
+        }
+
+        private BlockDisplay getBlockDisplay() {
+            return (BlockDisplay) Bukkit.getEntity(entityId);
+        }
 
     }
 }


### PR DESCRIPTION
Implemented a glow effect when highlighting claim blocks for better visibility. Also updated functions to include proper sending block updates to online players based on given positions. Added corresponding color identifiers for different claim types. Implemented checks for duplicate block highlighting.