### PR TITLE
feat: Add inactive claim pruning

### DIFF
--- a/common/src/main/java/net/william278/huskclaims/api/HuskClaimsAPI.java
+++ b/common/src/main/java/net/william278/huskclaims/api/HuskClaimsAPI.java
@@ -1109,7 +1109,7 @@ public class HuskClaimsAPI {
      * This will replace any existing active economy hook.
      *
      * @param hook the hook to register
-     * @since 1.0.4
+     * @since 1.1
      */
     public <T extends EconomyHook> void registerEconomyHook(@NotNull T hook) {
         plugin.getHook(EconomyHook.class).ifPresent(p -> plugin.getHooks().remove(p));
@@ -1243,7 +1243,7 @@ public class HuskClaimsAPI {
     /**
      * <b>(Internal use only)</b> - Get the plugin instance
      *
-     * @since 1.0.4
+     * @since 1.1
      */
     @ApiStatus.Internal
     public HuskClaims getPlugin() {

--- a/common/src/main/java/net/william278/huskclaims/claim/ClaimManager.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/ClaimManager.java
@@ -47,7 +47,7 @@ import java.util.logging.Level;
  *
  * @since 1.0
  */
-public interface ClaimManager extends ClaimHandler, ClaimEditor {
+public interface ClaimManager extends ClaimHandler, ClaimEditor, ClaimPruner {
 
     /**
      * Get the claim worlds
@@ -360,10 +360,14 @@ public interface ClaimManager extends ClaimHandler, ClaimEditor {
         }
         setClaimWorlds(loadedWorlds);
 
+        // Determine loaded claim worlds
         final Collection<ClaimWorld> claimWorlds = getClaimWorlds().values();
         final int claimCount = claimWorlds.stream().mapToInt(ClaimWorld::getClaimCount).sum();
         getPlugin().log(Level.INFO, String.format("Loaded %s claim(s) across %s world(s) in %s seconds",
                 claimCount, claimWorlds.size(), ChronoUnit.MILLIS.between(startTime, LocalTime.now()) / 1000d));
+
+        // Carry out pruning as necessary
+        pruneClaims();
     }
 
     /**
@@ -391,6 +395,7 @@ public interface ClaimManager extends ClaimHandler, ClaimEditor {
      * @param position The position to highlight the claim at
      * @since 1.0
      */
+    @SuppressWarnings("unused")
     default void highlightClaimAt(@NotNull OnlineUser user, @NotNull Position position) {
         getClaimWorld(position.getWorld()).flatMap(world -> world.getClaimAt(position))
                 .ifPresent(claim -> getHighlighter().startHighlighting(user, position.getWorld(), claim));

--- a/common/src/main/java/net/william278/huskclaims/claim/ClaimPruner.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/ClaimPruner.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of HuskClaims, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskclaims.claim;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import net.william278.huskclaims.HuskClaims;
+import net.william278.huskclaims.database.Database;
+import net.william278.huskclaims.user.ClaimBlocksManager.ClaimBlockSource;
+import net.william278.huskclaims.user.SavedUser;
+import net.william278.huskclaims.user.User;
+import org.jetbrains.annotations.Blocking;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
+
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import static net.william278.huskclaims.config.Settings.ClaimSettings;
+
+/**
+ * Interface for pruning claims created by inactive users
+ *
+ * @since 1.1
+ */
+public interface ClaimPruner {
+
+    /**
+     * Prunes claims on <b>this server</b> as per the plugin config.
+     * <p>
+     * This deletes all claims created by users marked inactive
+     * (those who have not logged on recently as configured in the plugin config).
+     * Claim blocks will be refunded accordingly.
+     *
+     * @since 1.1
+     */
+    @Blocking
+    default void pruneClaims() {
+        if (!getSettings().isEnabled()) {
+            return;
+        }
+
+        // Determine who to prune
+        final Set<ClaimWorld> toPrune = getWorldsToPrune();
+        final Set<User> inactiveUsers = Sets.intersection(getInactiveUsers(), getAllClaimers(toPrune));
+        final LocalTime startTime = LocalTime.now();
+        getPlugin().log(Level.INFO, String.format("Pruning %s claim worlds with claims by %s inactive users...",
+                toPrune.size(), inactiveUsers.size()));
+
+        // Carry out pruning
+        refundPrunedBlocks(pruneAndCalculateRefunds(toPrune, inactiveUsers));
+        getPlugin().log(Level.INFO, String.format("Successfully pruned claims in %s seconds",
+                ChronoUnit.MILLIS.between(startTime, LocalTime.now()) / 1000d));
+    }
+
+    // Prunes claim worlds
+    @NotNull
+    @Blocking
+    private Map<User, Long> pruneAndCalculateRefunds(@NotNull Set<ClaimWorld> worlds, @NotNull Set<User> users) {
+        final Map<User, Long> blocksToRefund = Maps.newHashMap();
+        worlds.stream()
+                .filter(w -> users.stream().anyMatch(u -> {
+                    final long blocks = w.getSurfaceClaimedBy(u);
+                    if (blocks > 0 && w.removeClaimsBy(u)) {
+                        blocksToRefund.compute(u, (k, v) -> v == null ? blocks : v + blocks);
+                        return true;
+                    }
+                    return false;
+                }))
+                .forEach(w -> getDatabase().updateClaimWorld(w));
+        return blocksToRefund;
+    }
+
+    // Refunds claim blocks based on a user map of blocks to refund
+    @Blocking
+    private void refundPrunedBlocks(@NotNull Map<User, Long> blocksToRefund) {
+        blocksToRefund.forEach((user, blocks) -> getPlugin().editClaimBlocks(
+                user,
+                ClaimBlockSource.CLAIMS_DELETED_PRUNED,
+                (b -> b + blocks)
+        ));
+    }
+
+    @NotNull
+    @Unmodifiable
+    default Set<ClaimWorld> getWorldsToPrune() {
+        return getPlugin().getClaimWorlds().entrySet().stream()
+                .filter((entry) -> getSettings().getExcludedWorlds().contains(entry.getKey()))
+                .map(Map.Entry::getValue).collect(Collectors.toSet());
+    }
+
+    @NotNull
+    @Unmodifiable
+    default Set<User> getAllClaimers(@NotNull Set<ClaimWorld> worlds) {
+        return worlds.stream().map(ClaimWorld::getClaimers)
+                .flatMap(Collection::stream).collect(Collectors.toSet());
+    }
+
+    @NotNull
+    default Set<User> getInactiveUsers() {
+        return getPlugin().getDatabase().getInactiveUsers(getSettings().getInactiveDays()).stream()
+                .map(SavedUser::getUser)
+                .filter(user -> !(getSettings().getExcludedUsers().contains(user.getUuid().toString())
+                        || getSettings().getExcludedUsers().contains(user.getName())))
+                .collect(Collectors.toSet());
+    }
+
+    @NotNull
+    private ClaimSettings.InactivityPruningSettings getSettings() {
+        return getPlugin().getSettings().getClaims().getInactivityPruning();
+    }
+
+    @NotNull
+    HuskClaims getPlugin();
+
+    @NotNull
+    Database getDatabase();
+
+}

--- a/common/src/main/java/net/william278/huskclaims/claim/ClaimWorld.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/ClaimWorld.java
@@ -38,10 +38,12 @@ import net.william278.huskclaims.user.Preferences;
 import net.william278.huskclaims.user.User;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -84,6 +86,10 @@ public class ClaimWorld {
                 .findFirst().orElseThrow(() -> new IllegalStateException("ClaimWorld not registered"));
     }
 
+    public long getSurfaceClaimedBy(@NotNull User owner) {
+        return getClaimsByUser(owner.getUuid()).stream().mapToInt(c -> c.getRegion().getSurfaceArea()).sum();
+    }
+
     public boolean removeClaimsBy(@NotNull User owner) {
         return claims.removeIf(claim -> claim.getOwner().map(owner.getUuid()::equals).orElse(false));
     }
@@ -101,6 +107,14 @@ public class ClaimWorld {
         return claims.stream().filter(claim -> claim.getOwner()
                 .map(o -> o.equals(uuid))
                 .orElse(uuid == null)).toList();
+    }
+
+    @NotNull
+    @Unmodifiable
+    public Set<User> getClaimers() {
+        return claims.stream()
+                .map(c -> c.getOwner().flatMap(this::getUser).orElse(null))
+                .filter(Objects::nonNull).collect(Collectors.toSet());
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/huskclaims/config/Settings.java
+++ b/common/src/main/java/net/william278/huskclaims/config/Settings.java
@@ -228,6 +228,28 @@ public final class Settings {
         @Comment("Whether to require confirmation when deleting claims that have children")
         private boolean confirmDeletingParentClaims = true;
 
+        @Comment("Settings for automatically removing claims made by now-inactive users")
+        private InactivityPruningSettings inactivityPruning = new InactivityPruningSettings();
+
+        @Getter
+        @Configuration
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        public static class InactivityPruningSettings {
+
+            @Comment("Whether to delete all claims made by users marked as inactive. (Warning: Dangerous!)")
+            private boolean enabled = false;
+
+            @Comment("The number of days a user must not log on for to be marked as inactive (Minimum: 1)")
+            private long inactiveDays = 60;
+
+            @Comment("List of worlds to exclude from being pruned.")
+            private List<String> excludedWorlds = Lists.newArrayList();
+
+            @Comment("List of users (by either UUID or username) to exclude from inactive claim pruning")
+            private List<String> excludedUsers = Lists.newArrayList();
+
+        }
+
         public boolean isWorldUnclaimable(@NotNull World world) {
             return unclaimableWorlds.stream().anyMatch(world.getName()::equalsIgnoreCase);
         }

--- a/common/src/main/java/net/william278/huskclaims/hook/EconomyHook.java
+++ b/common/src/main/java/net/william278/huskclaims/hook/EconomyHook.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Represents a hook for handling economy functions within the plugin
  *
- * @since 1.0.4
+ * @since 1.1
  */
 public abstract class EconomyHook extends Hook {
 
@@ -42,7 +42,7 @@ public abstract class EconomyHook extends Hook {
      *
      * @param name The name of the hook
      * @param api  the {@link HuskClaimsAPI API instance}
-     * @since 1.0.4
+     * @since 1.1
      */
     @SuppressWarnings("unused")
     public EconomyHook(@NotNull String name, @NotNull HuskClaimsAPI api) {
@@ -55,7 +55,7 @@ public abstract class EconomyHook extends Hook {
      * @param user   the user
      * @param amount the amount
      * @return whether the transaction was successful
-     * @since 1.0.4
+     * @since 1.1
      */
     public abstract boolean takeMoney(@NotNull OnlineUser user, double amount, @NotNull EconomyReason reason);
 

--- a/common/src/main/java/net/william278/huskclaims/moderation/SignListener.java
+++ b/common/src/main/java/net/william278/huskclaims/moderation/SignListener.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 /**
  * Interface for handling sign edits / placements, for moderation.
  *
- * @since 1.0.4
+ * @since 1.1
  */
 public interface SignListener {
 

--- a/common/src/main/java/net/william278/huskclaims/moderation/SignNotifier.java
+++ b/common/src/main/java/net/william278/huskclaims/moderation/SignNotifier.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Interface for notifying moderators of sign edits
  *
- * @since 1.0.4
+ * @since 1.1
  */
 public interface SignNotifier {
 

--- a/common/src/main/java/net/william278/huskclaims/user/ClaimBlocksManager.java
+++ b/common/src/main/java/net/william278/huskclaims/user/ClaimBlocksManager.java
@@ -57,13 +57,14 @@ public interface ClaimBlocksManager {
 
     default void editClaimBlocks(@NotNull User user, @NotNull UserManager.ClaimBlockSource source,
                                  @NotNull Function<Long, Long> consumer, @Nullable Consumer<Long> callback) {
-
+        // Calculate block balance
         final long originalBlocks = getClaimBlocks(user);
         final long newBlocks = consumer.apply(originalBlocks);
         if (newBlocks < 0) {
             throw new IllegalArgumentException("Claim blocks cannot be negative (" + newBlocks + ")");
         }
 
+        // Fire the event, update the blocks, trigger callback
         getPlugin().fireClaimBlocksChangeEvent(
                 user, originalBlocks, newBlocks, source,
                 (event) -> editSavedUser(user.getUuid(), (savedUser) -> {
@@ -124,6 +125,7 @@ public interface ClaimBlocksManager {
         CLAIM_CREATED,
         CLAIM_TRANSFER_AWAY,
         CLAIM_DELETED,
+        CLAIMS_DELETED_PRUNED,
         API;
 
         @NotNull

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -77,51 +77,51 @@ cross_server:
 claims:
   # Default flags for regular claims
   default_flags:
-    - PLAYER_DAMAGE_MONSTER
-    - EXPLOSION_DAMAGE_ENTITY
-    - PLAYER_DAMAGE_PLAYER
-    - MONSTER_SPAWN
-    - PASSIVE_MOB_SPAWN
+  - PLAYER_DAMAGE_MONSTER
+  - EXPLOSION_DAMAGE_ENTITY
+  - PLAYER_DAMAGE_PLAYER
+  - MONSTER_SPAWN
+  - PASSIVE_MOB_SPAWN
   # Default flags for admin claims
   admin_flags:
-    - PLAYER_DAMAGE_MONSTER
-    - EXPLOSION_DAMAGE_ENTITY
-    - PLAYER_DAMAGE_PLAYER
-    - MONSTER_SPAWN
-    - PASSIVE_MOB_SPAWN
+  - PLAYER_DAMAGE_MONSTER
+  - EXPLOSION_DAMAGE_ENTITY
+  - PLAYER_DAMAGE_PLAYER
+  - MONSTER_SPAWN
+  - PASSIVE_MOB_SPAWN
   # List of enabled claim types. Must include at least the regular "CLAIMS" mode
   enabled_claiming_modes:
-    - CLAIMS
-    - CHILD_CLAIMS
-    - ADMIN_CLAIMS
+  - CLAIMS
+  - CHILD_CLAIMS
+  - ADMIN_CLAIMS
   # Default flags for the wilderness (outside claims)
   wilderness_rules:
-    - BLOCK_PLACE
-    - BLOCK_BREAK
-    - BLOCK_INTERACT
-    - REDSTONE_INTERACT
-    - FARM_BLOCK_BREAK
-    - FARM_BLOCK_PLACE
-    - PLAYER_DAMAGE_PLAYER
-    - PLAYER_DAMAGE_MONSTER
-    - PLAYER_DAMAGE_ENTITY
-    - PLAYER_DAMAGE_PERSISTENT_ENTITY
-    - MONSTER_SPAWN
-    - PASSIVE_MOB_SPAWN
-    - MONSTER_DAMAGE_TERRAIN
-    - EXPLOSION_DAMAGE_TERRAIN
-    - EXPLOSION_DAMAGE_ENTITY
-    - FIRE_BURN
-    - FIRE_SPREAD
-    - FILL_BUCKET
-    - EMPTY_BUCKET
-    - PLACE_HANGING_ENTITY
-    - BREAK_HANGING_ENTITY
-    - ENTITY_INTERACT
-    - FARM_BLOCK_INTERACT
-    - USE_SPAWN_EGG
-    - ENDER_PEARL_TELEPORT
-    - CONTAINER_OPEN
+  - BLOCK_PLACE
+  - BLOCK_BREAK
+  - BLOCK_INTERACT
+  - REDSTONE_INTERACT
+  - FARM_BLOCK_BREAK
+  - FARM_BLOCK_PLACE
+  - PLAYER_DAMAGE_PLAYER
+  - PLAYER_DAMAGE_MONSTER
+  - PLAYER_DAMAGE_ENTITY
+  - PLAYER_DAMAGE_PERSISTENT_ENTITY
+  - MONSTER_SPAWN
+  - PASSIVE_MOB_SPAWN
+  - MONSTER_DAMAGE_TERRAIN
+  - EXPLOSION_DAMAGE_TERRAIN
+  - EXPLOSION_DAMAGE_ENTITY
+  - FIRE_BURN
+  - FIRE_SPREAD
+  - FILL_BUCKET
+  - EMPTY_BUCKET
+  - PLACE_HANGING_ENTITY
+  - BREAK_HANGING_ENTITY
+  - ENTITY_INTERACT
+  - FARM_BLOCK_INTERACT
+  - USE_SPAWN_EGG
+  - ENDER_PEARL_TELEPORT
+  - CONTAINER_OPEN
   # List of worlds where users cannot claim
   unclaimable_worlds: []
   # The number of claim blocks a user gets when they first join the server
@@ -143,15 +143,25 @@ claims:
   allow_nearby_claim_inspection: true
   # Whether to require confirmation when deleting claims that have children
   confirm_deleting_parent_claims: true
+  # Settings for automatically removing claims made by now-inactive users
+  inactivity_pruning:
+    # Whether to delete all claims made by users marked as inactive. (Warning: Dangerous!)
+    enabled: false
+    # The number of days a user must not log on for to be marked as inactive (Minimum: 1)
+    inactive_days: 60
+    # List of worlds to exclude from being pruned.
+    excluded_worlds: []
+    # List of users (by either UUID or username) to exclude from inactive claim pruning
+    excluded_users: []
 # Groups of operations that can be toggled on/off in claims
 operation_groups:
-  - name: Claim Explosions
-    description: Toggle whether explosions can damage terrain in claims
-    toggle_command_aliases:
-      - claimexplosions
-    allowed_operations:
-      - EXPLOSION_DAMAGE_TERRAIN
-      - MONSTER_DAMAGE_TERRAIN
+- name: Claim Explosions
+  description: Toggle whether explosions can damage terrain in claims
+  toggle_command_aliases:
+  - claimexplosions
+  allowed_operations:
+  - EXPLOSION_DAMAGE_TERRAIN
+  - MONSTER_DAMAGE_TERRAIN
 # Settings for user groups, letting users quickly manage trust for groups of multiple players at once
 user_groups:
   # Whether to enable user groups
@@ -209,7 +219,7 @@ pets:
 # Settings for moderation tools
 moderation:
   signs:
-    # Whether to notify users with /signspy on when signs are placed.edited. Requires Minecraft 1.19.4+
+    # Whether to notify users with /signspy on when signs are placed.edited. Requires Minecraft 1.19.4+Requires Minecraft 1.19.4+
     notify_moderators: true
     # Whether to filter messages
     filter_messages: false
@@ -223,7 +233,7 @@ moderation:
     # Whether to lock ground items dropped by players when they die from being picked up by others
     lock_items: true
     # Whether to also prevent death drops from being destroyed by lava, fire, cacti, etc.
-    prevent_destruction: false
+    prevent_destruction: true
 # Settings for integration hooks with other plugins
 hooks:
   luck_perms:

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -16,6 +16,7 @@ Welcome to the plugin documentation for HuskClaims v1.x+, the clean, cross-serve
 * 🎛️ [[Operation Groups]]
 * 🪧 [[Sign Moderation]]
 * 🪦 [[Drops Moderation]]
+* 😴 [[Inactivity Pruning]]
 * 🐕 [[Pets]]
 
 ## Developers

--- a/docs/Inactivity-Pruning.md
+++ b/docs/Inactivity-Pruning.md
@@ -1,0 +1,38 @@
+HuskClaims supports automatically pruning/expiring claims made by users if they have not logged in within a configurable period of time (in days). After being enabled, pruning will take place on each server during startup. Claims created by inactive users will have their claim blocks refunded.
+
+Please note that inactivity pruning will begin occurring immediately after enabling the setting. Take caution when turning this on, and consider making a backup of your database if necessary.
+
+## Automatic pruning
+To enable automatic claim pruning, edit the `inactivity_pruning` part of the claims section of your [`config.yml` file](config), setting `enabled` to true.
+
+<details>
+<summary>Automatic pruning (config.yml)</summary>
+
+```yaml
+  # Settings for automatically removing claims made by now-inactive users
+  inactivity_pruning:
+    # Whether to delete all claims made by users marked as inactive. (Warning: Dangerous!)
+    enabled: false
+    # The number of days a user must not log on for to be marked as inactive (Minimum: 1)
+    inactive_days: 60
+    # List of worlds to exclude from being pruned.
+    excluded_worlds: []
+    # List of users (by either UUID or username) to exclude from inactive claim pruning
+    excluded_users: []
+```
+</details>
+
+Here, you can additionally customize the number of days a user must not log in for them to be considered inactive (defaults to 60 days), and provide a list of claim world names that should not be pruned. 
+
+<details>
+<summary>Further pruning customisation (config.yml)</summary>
+
+```yaml
+    # List of worlds to exclude from being pruned.
+    excluded_worlds: [ 'world_the_end' ]
+    # List of users (by either UUID or username) to exclude from inactive claim pruning
+    excluded_users: [ 'William278', '2c9e9697-0517-4e7a-825d-916a2eaebd64' ]
+```
+</details>
+
+Finally, you may supply a list of UUIDs _or_ usernames of users to exclude from automatic pruning.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -13,6 +13,7 @@
 * 🎛️ [[Operation Groups]]
 * 🪧 [[Sign Moderation]]
 * 🪦 [[Drops Moderation]]
+* 😴 [[Inactivity Pruning]]
 * 🐕 [[Pets]]
 
 ## Developers

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ javaVersion=17
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
 
-plugin_version=1.0.4
+plugin_version=1.1
 plugin_archive=huskclaims
 plugin_description=A clean, cross-server compatible grief prevention plugin
 


### PR DESCRIPTION
Closes #34

Adds automatic claim pruning (aka "claim expiry"), letting claims automatically expire after a configurable period of time. Also bumps the plugin to v1.1.