### PR TITLE
Add a WorldGuard hook

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ allprojects {
         maven { url 'https://api.modrinth.com/maven/' }
         maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
         maven { url 'https://jitpack.io' }
+        maven { url "https://maven.enginehub.org/repo/" }
     }
 
     dependencies {

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compileOnly 'net.william278.husktowns:husktowns-bukkit:3.0.4'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7.1'
     compileOnly 'me.clip:placeholderapi:2.11.5'
+    compileOnly 'com.sk89q.worldguard:worldguard-bukkit:7.1.0-SNAPSHOT'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.32'
 }

--- a/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitHookProvider.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitHookProvider.java
@@ -46,6 +46,9 @@ public interface BukkitHookProvider extends HookProvider {
         if (isDependencyAvailable("PlaceholderAPI") && settings.getPlaceholders().isEnabled()) {
             hooks.add(new BukkitPlaceholderAPIHook(getPlugin()));
         }
+        if(isDependencyAvailable("WorldGuard") && settings.getWorldGuard().isEnabled()) {
+            hooks.add(new BukkitWorldGuardHook(getPlugin()));
+        }
 
         // Add bukkit importers
         hooks.add(new BukkitGriefPreventionImporter(getPlugin()));

--- a/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitWorldGuardHook.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitWorldGuardHook.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of HuskClaims, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskclaims.hook;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.regions.RegionType;
+import net.william278.huskclaims.HuskClaims;
+import net.william278.huskclaims.claim.Region;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+
+public class BukkitWorldGuardHook extends WorldGuardHook {
+
+
+    public BukkitWorldGuardHook(@NotNull HuskClaims plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public boolean isChunkInRestrictedRegion(@NotNull Region region, @NotNull String worldName) {
+        final World bukkitWorld = Bukkit.getWorld(worldName);
+        if (bukkitWorld == null) return false;
+        final RegionManager regionManager = WorldGuard.getInstance().getPlatform().getRegionContainer()
+                .get(BukkitAdapter.adapt(bukkitWorld));
+        if (regionManager == null) {
+            return false;
+        }
+
+        final BlockVector3 min = BlockVector3.at(region.getNearCorner().getBlockX(), -64, region.getNearCorner().getBlockZ());
+        final BlockVector3 max = BlockVector3.at(region.getFarCorner().getBlockX(), 320, region.getFarCorner().getBlockZ());
+
+        final ProtectedRegion chunkRegion = new ProtectedCuboidRegion("dummy", min, max);
+        final ApplicableRegionSet applicableRegions = regionManager.getApplicableRegions(chunkRegion);
+        return applicableRegions.getRegions().stream()
+                .anyMatch(wgRegion -> !wgRegion.getType().equals(RegionType.GLOBAL));
+    }
+
+}

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -20,3 +20,4 @@ softdepend:
   - 'Pl3xMap'
   - 'BlueMap'
   - 'dynmap'
+  - 'WorldGuard'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     compileOnly 'us.dynmap:DynmapCoreAPI:3.6'
     compileOnly 'maven.modrinth:pl3xmap:1.20.4-492'
     compileOnly 'com.github.plan-player-analytics:Plan:5.6.2820'
+    compileOnly 'com.sk89q.worldguard:worldguard-core:7.1.0-SNAPSHOT'
 
     testImplementation 'com.github.plan-player-analytics:Plan:5.6.2820'
     testImplementation 'com.google.guava:guava:33.2.0-jre'

--- a/common/src/main/java/net/william278/huskclaims/claim/ClaimEditor.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/ClaimEditor.java
@@ -302,7 +302,7 @@ public interface ClaimEditor {
             getPlugin().getHighlighter().startHighlighting(user, user.getWorld(), overlapsWith, true);
             return true;
         }
-        if(worldGuardOverlap){
+        if (worldGuardOverlap) {
             getPlugin().getLocales().getLocale("land_selection_overlaps_worldguard")
                     .ifPresent(user::sendMessage);
             return true;

--- a/common/src/main/java/net/william278/huskclaims/claim/ClaimEditor.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/ClaimEditor.java
@@ -23,6 +23,7 @@ import lombok.Builder;
 import lombok.Getter;
 import net.william278.huskclaims.HuskClaims;
 import net.william278.huskclaims.highlighter.Highlightable;
+import net.william278.huskclaims.hook.WorldGuardHook;
 import net.william278.huskclaims.position.BlockPosition;
 import net.william278.huskclaims.position.Position;
 import net.william278.huskclaims.trust.TrustLevel;
@@ -291,12 +292,22 @@ public interface ClaimEditor {
 
     private boolean doesClaimOverlap(@NotNull OnlineUser user, @NotNull ClaimWorld world, @NotNull Region region) {
         final List<Claim> overlapsWith = world.getParentClaimsOverlapping(region);
+        final boolean worldGuardOverlap = getPlugin().getHook(WorldGuardHook.class)
+                .map(hook -> hook.isChunkInRestrictedRegion(region, world.getName(getPlugin())))
+                .orElse(false);
+
         if (!overlapsWith.isEmpty()) {
             getPlugin().getLocales().getLocale("land_selection_overlaps", Integer.toString(overlapsWith.size()))
                     .ifPresent(user::sendMessage);
             getPlugin().getHighlighter().startHighlighting(user, user.getWorld(), overlapsWith, true);
             return true;
         }
+        if(worldGuardOverlap){
+            getPlugin().getLocales().getLocale("land_selection_overlaps_worldguard")
+                    .ifPresent(user::sendMessage);
+            return true;
+        }
+
         return false;
     }
 

--- a/common/src/main/java/net/william278/huskclaims/config/Settings.java
+++ b/common/src/main/java/net/william278/huskclaims/config/Settings.java
@@ -556,6 +556,16 @@ public final class Settings {
             private boolean enabled = true;
         }
 
+        private WorldGuardSettings worldGuard = new WorldGuardSettings();
+
+        @Getter
+        @Configuration
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        public static class WorldGuardSettings {
+            @Comment("Whether to hook into WorldGuard to use huskclaims-claim flag inside WorldGuard regions")
+            private boolean enabled = true;
+        }
+
         private MapHookSettings map = new MapHookSettings();
 
         @Getter

--- a/common/src/main/java/net/william278/huskclaims/hook/WorldGuardHook.java
+++ b/common/src/main/java/net/william278/huskclaims/hook/WorldGuardHook.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of HuskClaims, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskclaims.hook;
+
+import net.william278.huskclaims.HuskClaims;
+import net.william278.huskclaims.claim.Region;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class WorldGuardHook extends Hook {
+
+
+    protected WorldGuardHook(@NotNull HuskClaims plugin) {
+        super("WorldGuard", plugin);
+    }
+
+    @Override
+    public void load() {
+    }
+
+    @Override
+    public void unload() {
+    }
+
+    public abstract boolean isChunkInRestrictedRegion(@NotNull Region region, @NotNull String worldName);
+}

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -38,6 +38,7 @@ locales:
   world_not_claimable: '[Claiming is disabled in this world.](#ff7e5e)'
   land_already_claimed: '[This land has already been claimed by %1%.](#ff7e5e)'
   land_selection_overlaps: '[This land selection overlaps %1% existing claim(s).](#ff7e5e)'
+  land_selection_overlaps_worldguard: '[This land selection overlaps with a WorldGuard region.](#ff7e5e)'
   land_selection_overlaps_child: '[This land selection overlaps with %1% other child claim(s).](#ff7e5e)'
   land_already_child_claim: '[This area of the claim is already designated as a child claim.](#ff7e5e)'
   husktowns_claim_overlaps: '[Cannot claim here as it overlaps with a player claim.](#ff7e5e)'

--- a/common/src/main/resources/locales/ro-ro.yml
+++ b/common/src/main/resources/locales/ro-ro.yml
@@ -38,6 +38,7 @@ locales:
   world_not_claimable: '[Revendicarea este dezactivată în această lume.](#ff7e5e)'
   land_already_claimed: '[Acest teren a fost revendicat deja de către %1%.](#ff7e5e)'
   land_selection_overlaps: '[Această selecție de teren se suprapune cu %1% revendicări existente.](#ff7e5e)'
+  land_selection_overlaps_worldguard: '[Această selecție de teren se suprapune cu o regiune WorldGuard.](#ff7e5e)'
   land_selection_overlaps_child: '[Această selecție de teren se suprapune cu %1% alte revendicări fiu.](#ff7e5e)'
   land_already_child_claim: '[Această zonă a revendicării este deja desemnată ca o revendicare   fiu.](#ff7e5e)'
   husktowns_claim_overlaps: '[Nu se poate revendica aici deoarece se suprapune cu revendicarea unui jucător.](#ff7e5e)'

--- a/common/src/main/resources/locales/ru-ru.yml
+++ b/common/src/main/resources/locales/ru-ru.yml
@@ -38,6 +38,7 @@ locales:
   world_not_claimable: '[В этом мире приваты отключены.](#ff7e5e)'
   land_already_claimed: '[Выделенная территория уже занята игроком %1%.](#ff7e5e)'
   land_selection_overlaps: '[Выделенная территория пересекается с %1% уже существующим(и) регионом(ами).](#ff7e5e)'
+  land_selection_overlaps_worldguard: '[Этот выбор земли совпадает с регионом WorldGuard.](#ff7e5e)'
   land_selection_overlaps_child: '[Выбранная территория пересекается с %1% уже существующими потомственным(и) регионом(ами).](#ff7e5e)'
   land_already_child_claim: '[Выделенная территория уже является потомственным регионом.](#ff7e5e)'
   husktowns_claim_overlaps: '[Cannot claim here as it overlaps with a player claim.](#ff7e5e)'

--- a/common/src/main/resources/locales/zh-cn.yml
+++ b/common/src/main/resources/locales/zh-cn.yml
@@ -38,6 +38,7 @@ locales:
   world_not_claimable: '[在此世界中无法声明](#ff7e5e)'
   land_already_claimed: '[此地已被%1%声明](#ff7e5e)'
   land_selection_overlaps: '[此领地选择与%1%现有领地重叠](#ff7e5e)'
+  land_selection_overlaps_worldguard: '[此土地选择与 WorldGuard 区域重叠.](#ff7e5e)'
   land_selection_overlaps_child: '[此领地选择与%1%其他子领地重叠](#ff7e5e)'
   land_already_child_claim: '[此领地的此区域已被指定为子领地](#ff7e5e)'
   husktowns_claim_overlaps: '[无法在此处声明因为它与玩家领地重叠](#ff7e5e)'

--- a/paper/src/main/resources/paper-plugin.yml
+++ b/paper/src/main/resources/paper-plugin.yml
@@ -44,3 +44,7 @@ dependencies:
       load: BEFORE
       required: false
       join-classpath: true
+    WorldGuard:
+      load: BEFORE
+      required: false
+      join-classpath: true


### PR DESCRIPTION
Do not overlap HuskClaims claims on Worldguard regions
I would have liked to make a WorldGuard flag like the one on HuskTowns 
but RedisClaims hooks don't implement a method called by JavaPlugin onLoad()
and WorldGuard allows flags registration only on plugin load phase