### PR TITLE
feat: drop handling for fabric

### DIFF
--- a/common/src/main/java/net/william278/huskclaims/moderation/DropsHandler.java
+++ b/common/src/main/java/net/william278/huskclaims/moderation/DropsHandler.java
@@ -53,18 +53,22 @@ public interface DropsHandler {
             return;
         }
         removeIfMarkedDropper(item.getStack()).ifPresent(owner -> {
-            lockDrops(item, owner);
+            lockDrop(owner, item);
             getMarkedDrops().get(owner).remove(item.getStack());
         });
     }
 
-    default void lockDrops(@NotNull GroundStack item, @NotNull UUID owner) {
-        item.lock(owner, getSettings().isPreventDestruction());
+    default void lockDrop(@NotNull UUID owner, @NotNull GroundStack item) {
+        lockDrops(owner, Lists.newArrayList(item));
+    }
+
+    default void lockDrops(@NotNull UUID owner, @NotNull Collection<? extends GroundStack> items) {
+        items.forEach(item -> item.lock(owner, getSettings().isPreventDestruction()));
         if (getTrackedItems().containsKey(owner)) {
-            getTrackedItems().get(owner).add(item);
+            getTrackedItems().get(owner).addAll(items);
             return;
         }
-        getTrackedItems().put(owner, Sets.newHashSet(item));
+        getTrackedItems().put(owner, Sets.newHashSet(items));
     }
 
     //TODO: Future - permit globally unlocking via a network message?

--- a/fabric/src/main/java/net/william278/huskclaims/listener/FabricDropsListener.java
+++ b/fabric/src/main/java/net/william278/huskclaims/listener/FabricDropsListener.java
@@ -19,5 +19,97 @@
 
 package net.william278.huskclaims.listener;
 
+import java.util.Collection;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.william278.huskclaims.FabricHuskClaims;
+import net.william278.huskclaims.moderation.DropsHandler;
+import net.william278.huskclaims.user.OnlineUser;
+import net.william278.huskclaims.util.Location;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public interface FabricDropsListener {
+
+    default void onPlayerDeath(ServerPlayerEntity player, Collection<ItemEntity> items) {
+        if (items.isEmpty() || !getPlugin().getSettings().getModeration().getDrops().isLockItems()) {
+            return;
+        }
+        OnlineUser user = getPlugin().getOnlineUser(player);
+        getPlugin().lockDrops(
+            user.getUuid(),
+            items.stream().map(FabricGroundItem::new).toList()
+        );
+        getPlugin().getLocales().getLocale("death_drops_locked")
+            .ifPresent(user::sendMessage);
+    }
+
+    @NotNull
+    FabricHuskClaims getPlugin();
+
+    @Getter
+    class FabricDroppedItem implements DropsHandler.DroppedItem {
+
+        private final ItemStack stack;
+        private final Location dropLocation;
+
+        FabricDroppedItem(@NotNull ItemStack stack, @NotNull Location dropLocation) {
+            this.stack = stack;
+            this.dropLocation = dropLocation;
+        }
+
+        public double distance(@NotNull FabricDroppedItem other) {
+            return Objects.equals(dropLocation.world(), other.dropLocation.world())
+                ? dropLocation.pos().distanceTo(other.getDropLocation().pos()) : Double.MAX_VALUE;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof FabricDroppedItem item
+                && this.distance(item) <= DEATH_DROPS_EQUAL_RANGE
+                && item.getStack() != null && item.getStack().equals(getStack());
+        }
+
+    }
+
+    class FabricGroundItem implements DropsHandler.GroundStack {
+
+        @NotNull
+        @Getter
+        private final ItemEntity entity;
+
+        @Nullable
+        private UUID owner;
+
+        public FabricGroundItem(@NotNull ItemEntity entity) {
+            this.entity = entity;
+        }
+
+        public void lock(@NotNull UUID owner, boolean preventDestruction) {
+            this.owner = owner;
+            updateEntity(preventDestruction);
+        }
+
+        public void unlock() {
+            this.owner = null;
+            updateEntity(false);
+        }
+
+        private void updateEntity(boolean preventDestruction) {
+            entity.setInvulnerable(owner != null && preventDestruction);
+            entity.setOwner(owner);
+        }
+
+        @Override
+        @NotNull
+        public DropsHandler.DroppedItem getStack() {
+            return new FabricDroppedItem(entity.getStack(), new Location(entity));
+        }
+
+    }
+
 }

--- a/fabric/src/main/java/net/william278/huskclaims/listener/FabricListener.java
+++ b/fabric/src/main/java/net/william278/huskclaims/listener/FabricListener.java
@@ -76,6 +76,7 @@ public class FabricListener extends FabricOperationListener implements FabricPet
         ServerLivingEntityEvents.ALLOW_DAMAGE.register(this::onPlayerDamageTamed);
         UseEntityCallback.EVENT.register(this::onPlayerTamedInteract);
         PlayerActionEvents.BEFORE_CHANGE_TEXT_ON_SIGN.register(this::onSignEdit);
+        PlayerActionEvents.AFTER_DEATH_DROP_ITEMS.register(this::onPlayerDeath);
     }
 
     private void onPlayerJoin(ServerPlayNetworkHandler handler, PacketSender sender, MinecraftServer server) {

--- a/fabric/src/main/java/net/william278/huskclaims/mixins/PlayerInventoryMixin.java
+++ b/fabric/src/main/java/net/william278/huskclaims/mixins/PlayerInventoryMixin.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of HuskClaims, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.huskclaims.mixins;
+
+import com.google.common.collect.Lists;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import java.util.List;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.william278.huskclaims.util.PlayerActionEvents;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerInventory.class)
+public class PlayerInventoryMixin {
+
+    @Shadow
+    @Final
+    public PlayerEntity player;
+
+    @Inject(method = "dropAll", at = @At("HEAD"))
+    private void dropAllHeadMixin(CallbackInfo ci, @Share("items") LocalRef<List<ItemEntity>> itemsLocalRef) {
+        itemsLocalRef.set(Lists.newArrayList());
+    }
+
+    @ModifyExpressionValue(method = "dropAll", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;dropItem(Lnet/minecraft/item/ItemStack;ZZ)Lnet/minecraft/entity/ItemEntity;"))
+    private ItemEntity dropAllMixin(ItemEntity original, @Share("items") LocalRef<List<ItemEntity>> itemsLocalRef) {
+        itemsLocalRef.get().add(original);
+        return original;
+    }
+
+    @Inject(method = "dropAll", at = @At("TAIL"))
+    private void dropAllTailMixin(CallbackInfo ci, @Share("items") LocalRef<List<ItemEntity>> itemsLocalRef) {
+        PlayerActionEvents.AFTER_DEATH_DROP_ITEMS.invoker().dropItems((ServerPlayerEntity) player, itemsLocalRef.get());
+    }
+
+}

--- a/fabric/src/main/java/net/william278/huskclaims/util/PlayerActionEvents.java
+++ b/fabric/src/main/java/net/william278/huskclaims/util/PlayerActionEvents.java
@@ -19,10 +19,12 @@
 
 package net.william278.huskclaims.util;
 
+import java.util.Collection;
 import java.util.List;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.filter.FilteredMessage;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -51,6 +53,16 @@ public final class PlayerActionEvents {
         }
     );
 
+    @NotNull
+    public static final Event<AfterDeathDropItems> AFTER_DEATH_DROP_ITEMS = EventFactory.createArrayBacked(
+        AfterDeathDropItems.class,
+        (callbacks) -> (player, items) -> {
+            for (AfterDeathDropItems listener : callbacks) {
+                listener.dropItems(player, items);
+            }
+        }
+    );
+
     @FunctionalInterface
     public interface AfterSwapHands {
 
@@ -62,6 +74,13 @@ public final class PlayerActionEvents {
     public interface BeforeChangeTextOnSign {
 
         List<FilteredMessage> changeTextOnSign(SignBlockEntity sign, ServerPlayerEntity player, boolean front, List<FilteredMessage> messages);
+
+    }
+
+    @FunctionalInterface
+    public interface AfterDeathDropItems {
+
+        void dropItems(ServerPlayerEntity player, Collection<ItemEntity> items);
 
     }
 

--- a/fabric/src/main/resources/huskclaims.mixins.json
+++ b/fabric/src/main/resources/huskclaims.mixins.json
@@ -4,6 +4,7 @@
   "package": "net.william278.huskclaims.mixins",
   "compatibilityLevel": "JAVA_17",
   "server": [
+    "PlayerInventoryMixin",
     "ServerPlayNetworkHandlerMixin",
     "SignBlockEntityMixin"
   ],


### PR DESCRIPTION
- Added a new event that is called when `PlayerInventory#dropAll` is called. It returns the `ItemEntity` list.

- There is no need for `FabricDroppedItem`, but I left it because it is needed for `GroundStack#getStack`

- Renamed the `lockDrops` method to `lockDrop` and added the `lockDrops` method