### PR TITLE
build: `api` dependencies from `common` and `common` must be included for fabric

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     modImplementation include("eu.pb4:placeholder-api:${fabric_placeholder_api_version}")
     modImplementation include("net.impactdev.impactor.api:economy:${fabric_impactor_api_version}")
     modImplementation include("net.william278.cloplib:cloplib-fabric:2.0+$project.name")
-    modCompileOnly "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}"
 
     implementation include('org.apache.commons:commons-pool2:2.12.0')
     implementation include("org.xerial:sqlite-jdbc:$sqlite_driver_version")

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -30,8 +30,13 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok:1.18.36'
 
-//    shadow project(path: ":common") // TODO - remove, for debug only
-    implementation project(path: ":common")
+    implementation include(project(path: ":common"))
+    project(":common").configurations.api.dependencies.each { dependency ->
+        if (dependency.name in ['cloplib-common', 'gson']) { // skip because it already exists (e.g. in cloplib-fabric)
+            return
+        }
+        include("${dependency.group}:${dependency.name}:${dependency.version}")
+    }
 }
 
 processResources {
@@ -51,24 +56,6 @@ shadowJar {
     exclude('net.fabricmc:.*')
     exclude('net.kyori:.*')
     exclude '/mappings/*'
-
-    relocate 'net.jodah', 'net.william278.huskclaims.libraries'
-    relocate 'org.apache.commons.io', 'net.william278.huskclaims.libraries.commons.io'
-    relocate 'org.apache.commons.text', 'net.william278.huskclaims.libraries.commons.text'
-    relocate 'org.apache.commons.lang3', 'net.william278.huskclaims.libraries.commons.lang3'
-    relocate 'de.themoep', 'net.william278.huskclaims.libraries'
-    relocate 'org.jetbrains', 'net.william278.huskclaims.libraries'
-    relocate 'org.intellij', 'net.william278.huskclaims.libraries'
-    relocate 'com.zaxxer', 'net.william278.huskclaims.libraries'
-    relocate 'net.william278.paginedown', 'net.william278.huskclaims.libraries.paginedown'
-    relocate 'net.william278.desertwell', 'net.william278.huskclaims.libraries.desertwell'
-    relocate 'net.william278.cloplib', 'net.william278.huskclaims.libraries.cloplib'
-    relocate 'org.json', 'net.william278.huskclaims.libraries.json'
-    relocate 'dev.dejvokep.boostedyaml', 'net.william278.huskclaims.libraries.boostedyaml'
-    relocate 'org.snakeyaml', 'net.william278.huskclaims.libraries.snakeyaml'
-    relocate 'com.google.gson', 'net.william278.huskclaims.libraries.gson'
-    relocate 'com.fatboyindustrial', 'net.william278.huskclaims.libraries'
-    relocate 'de.exlll', 'net.william278.huskclaims.libraries'
 }
 
 remapJar {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -35,7 +35,7 @@ dependencies {
         if (dependency.name in ['cloplib-common', 'gson']) { // skip because it already exists (e.g. in cloplib-fabric)
             return
         }
-        include("${dependency.group}:${dependency.name}:${dependency.version}")
+        include(dependency)
     }
 }
 


### PR DESCRIPTION
The current builds does not contain `common`, in addition to the current solution, we can also use `shadow`, but in this case we will need to use it for everything in `fabric` with `include`