### PR TITLE
feat: permissions for flags

### DIFF
--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -37,6 +37,8 @@ locales:
   error_cannot_ban_self: '[Error:](#ff3300) [You cannot ban yourself from a claim.](#ff7e5e)'
   error_ban_list_empty: '[Error:](#ff3300) [No players have been banned from this claim.](#ff7e5e)'
   error_not_trapped: '[Error:](#ff3300) [You can build here—find a way out by yourself!](#ff7e5e)'
+  error_no_permission_flag: '[Error:](#ff3300) [You do not have permission to use the %1% flag.](#ff7e5e)'
+  error_no_flags: '[Error:](#ff3300) [You don''t have any flags available.](#ff7e5e)'
   group_list: '[List of your groups:](#00fb9a) [%1%](gray)'
   group_list_item: '[%1%](white show_text=&7Group of %2% players:\n&8 run_command=/group %1%)'
   group_member_list: '[List of group members of %1%:](#00fb9a) %2%'

--- a/common/src/main/resources/locales/it-it.yml
+++ b/common/src/main/resources/locales/it-it.yml
@@ -37,6 +37,8 @@ locales:
   error_cannot_ban_self: '[Errore:](#ff3300) [Non puoi bannare te stesso da un claim.](#ff7e5e)'
   error_ban_list_empty: '[Errore:](#ff3300) [Nessun giocatore è stato bannato da questo claim.](#ff7e5e)'
   error_not_trapped: '[Errore:](#ff3300) [Puoi costruire qui—trova un modo per uscire da solo!](#ff7e5e)'
+  error_no_permission_flag: '[Error:](#ff3300) [You do not have permission to use the %1% flag.](#ff7e5e)'
+  error_no_flags: '[Error:](#ff3300) [You don''t have any flags available.](#ff7e5e)'
   group_list: '[Lista dei tuoi gruppi:](#00fb9a) [%1%](gray)'
   group_list_item: '[%1%](white show_text=&7Gruppo di %2% giocatori:\n&8 run_command=/group %1%)'
   group_member_list: '[Lista dei membri del gruppo %1%:](#00fb9a) %2%'

--- a/common/src/main/resources/locales/ro-ro.yml
+++ b/common/src/main/resources/locales/ro-ro.yml
@@ -37,6 +37,8 @@ locales:
   error_cannot_ban_self: '[Error:](#ff3300) [You cannot ban yourself from a claim.](#ff7e5e)'
   error_ban_list_empty: '[Error:](#ff3300) [No players have been banned from this claim.](#ff7e5e)'
   error_not_trapped: '[Error:](#ff3300) [You can build here—find a way out by yourself!](#ff7e5e)'
+  error_no_permission_flag: '[Error:](#ff3300) [You do not have permission to use the %1% flag.](#ff7e5e)'
+  error_no_flags: '[Error:](#ff3300) [You don''t have any flags available.](#ff7e5e)'
   group_list: '[Lista grupurilor tale:](#00fb9a) [%1%](gray)'
   group_list_item: '[%1%](white show_text=&7Grup de %2% jucători:\n&8 run_command=/group %1%)'
   group_member_list: '[Lista membrilor grupului %1%:](#00fb9a) %2%'

--- a/common/src/main/resources/locales/ru-ru.yml
+++ b/common/src/main/resources/locales/ru-ru.yml
@@ -37,6 +37,8 @@ locales:
   error_cannot_ban_self: '[Ошибка:](#ff3300) [Вы не можете заблокировать себя в привате.](#ff7e5e)'
   error_ban_list_empty: '[Ошибка:](#ff3300) [В этом привате нет заблокированных игроков.](#ff7e5e)'
   error_not_trapped: '[Ошибка:](#ff3300) [Вы можете строить здесь — найдите выход самостоятельно!](#ff7e5e)'
+  error_no_permission_flag: '[Ошибка:](#ff3300) [У вас нет доступа к флагу %1%.](#ff7e5e)'
+  error_no_flags: '[Ошибка:](#ff3300) [У вас нет доступных флагов.](#ff7e5e)'
   group_list: '[Список ваших групп:](#00fb9a) [%1%](gray)'
   group_list_item: '[%1%](white show_text=&7Группа из %2%-х игроков:\n&8 run_command=/group %1%)'
   group_member_list: '[Список участников группы %1%:](#00fb9a) %2%'

--- a/common/src/main/resources/locales/zh-cn.yml
+++ b/common/src/main/resources/locales/zh-cn.yml
@@ -37,6 +37,8 @@ locales:
   error_cannot_ban_self: '[错误:](#ff3300) [你不能将自己从该领地中封禁.](#ff7e5e)'
   error_ban_list_empty: '[错误:](#ff3300) [无玩家被该领地封禁.](#ff7e5e)'
   error_not_trapped: '[错误:](#ff3300) [你可以在这里破坏方块—还是找找路自己出去吧!](#ff7e5e)'
+  error_no_permission_flag: '[Error:](#ff3300) [You do not have permission to use the %1% flag.](#ff7e5e)'
+  error_no_flags: '[Error:](#ff3300) [You don''t have any flags available.](#ff7e5e)'
   group_list: '[创建的组列表:](#00fb9a) [%1%](gray)'
   group_list_item: '[%1%](white show_text=&7组 %2% 中的玩家:\n&8 run_command=/group %1%)'
   group_member_list: '[组 %1% 中的玩家:](#00fb9a) %2%'

--- a/common/src/main/resources/locales/zh-tw.yml
+++ b/common/src/main/resources/locales/zh-tw.yml
@@ -37,6 +37,8 @@ locales:
   error_cannot_ban_self: '[錯誤：](#ff3300) [您無法禁止自己進入領地。](#ff7e5e)'
   error_ban_list_empty: '[錯誤：](#ff3300) [沒有玩家被禁止進入此領地。](#ff7e5e)'
   error_not_trapped: '[Error:](#ff3300) [You can build here—find a way out by yourself!](#ff7e5e)'
+  error_no_permission_flag: '[Error:](#ff3300) [You do not have permission to use the %1% flag.](#ff7e5e)'
+  error_no_flags: '[Error:](#ff3300) [You don''t have any flags available.](#ff7e5e)'
   group_list: '[您的群組清單：](#00fb9a) [%1%](gray)'
   group_list_item: '[%1%](white show_text=&7%2% 位玩家的群組：\n&8 run_command=/group %1%)'
   group_member_list: '[%1% 的群組成員清單：](#00fb9a) %2%'

--- a/docs/Permissions.md
+++ b/docs/Permissions.md
@@ -42,3 +42,10 @@ These permissions restrict being able to use certain trust tags when granting tr
 | `huskclaims.trust.luckperms` | Use the `#role/(name)` trust tags in claims to grant LuckPerms role-based access. Requires the LuckPerms hook. |    ❌    |
 
 You can turn off the permission requirement for using LuckPerms groups in claims in the [[config]] hook settings. 
+
+## Flags
+These permissions restrict the use of flags.
+
+| Permission                       | Description        | Default |
+|----------------------------------|--------------------|:-------:|
+| `huskclaims.flag.<name of flag>` | Access to the flag |    ✅    |


### PR DESCRIPTION
This pull request introduces several enhancements to the `ClaimFlagsCommand` class and updates localization files to support new error messages. The primary changes include adding permission checks for managing claim flags and updating the locales to reflect these changes.

Enhancements to `ClaimFlagsCommand`:

* Added a new static final string `FLAG_PERMISSION` for flag-related permissions.
* Introduced the `canManageFlag` method to check if a user has permission to manage a specific flag.
* Updated the `suggest` method to filter operation types based on user permissions.
* Modified the `handleSetClaimFlag` method to include permission checks before setting a flag.
* Updated the `sendClaimFlagsList` method to filter flags based on user permissions and handle cases where no flags are available. [[1]](diffhunk://#diff-3585e9005d773bcb6d0fb02a4908aaa467c434e49efa666ed56bd2737f009489L119-R147) [[2]](diffhunk://#diff-3585e9005d773bcb6d0fb02a4908aaa467c434e49efa666ed56bd2737f009489L137-R159)

Localization updates:

* Added new error messages `error_no_permission_flag` and `error_no_flags` in multiple locale files (`en-gb.yml`, `it-it.yml`, `ro-ro.yml`, `ru-ru.yml`, `zh-cn.yml`, `zh-tw.yml`). [[1]](diffhunk://#diff-b8516396fbd7ba97015439c50c9e2002ca40f45fc44c7d107b06e9d0904e2b4cR40-R41) [[2]](diffhunk://#diff-e5b8337c578ab3790146fed08716863da5ef8ecd8e887b871a00d739adcf4a97R40-R41) [[3]](diffhunk://#diff-83c1862007726ed4675bd695b3c0d9ba1bf5571480233b21ad6fcf4b73345a5fR40-R41) [[4]](diffhunk://#diff-fddec5917c793ff8fc7ab48d5b66b6ecd0a5c3a82c470ab10daf772a79663d30R40-R41) [[5]](diffhunk://#diff-7a01775eb034b8c0eb17adc65c1d68c8767ac38cbd0f2bbb96ac3b32f48bd86dR40-R41) [[6]](diffhunk://#diff-d52fb01d21e8ac69026acb6168a4ea0f82402ed4492661d53324a7f6c09682d1R40-R41)

Documentation update:

* Added a new section in `Permissions.md` to document the flag permissions.