### PR TITLE
fix and improve fabric hook to HuskHomes

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation include("org.mariadb.jdbc:mariadb-java-client:$mariadb_driver_version")
     implementation include("redis.clients:jedis:$jedis_version")
 
-    compileOnly "net.william278.huskhomes:huskhomes-fabric:4.9-2aaf674+$project.name"
+    modImplementation "net.william278.huskhomes:huskhomes-fabric:4.9-2aaf674+$project.name"
     compileOnly 'org.jetbrains:annotations:26.0.1'
     compileOnly 'org.projectlombok:lombok:1.18.36'
 

--- a/fabric/src/main/java/net/william278/huskclaims/FabricHuskClaims.java
+++ b/fabric/src/main/java/net/william278/huskclaims/FabricHuskClaims.java
@@ -30,6 +30,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -102,6 +103,7 @@ public class FabricHuskClaims implements DedicatedServerModInitializer, HuskClai
         FabricHookProvider, ServerPlayNetworking.PlayPayloadHandler<FabricPluginMessage> {
 
     public static final Logger LOGGER = LoggerFactory.getLogger("HuskClaims");
+    public static final Identifier INITIAL_PHASE = Identifier.of("huskclaims", "on_enable");
     private final ModContainer mod = FabricLoader.getInstance().getModContainer("huskclaims")
             .orElseThrow(() -> new RuntimeException("Failed to get Mod Container"));
     private final Map<String, Boolean> permissions = Maps.newHashMap();
@@ -153,7 +155,8 @@ public class FabricHuskClaims implements DedicatedServerModInitializer, HuskClai
         this.load();
         this.loadCommands();
 
-        ServerLifecycleEvents.SERVER_STARTING.register(this::onEnable);
+        ServerLifecycleEvents.SERVER_STARTING.addPhaseOrdering(Event.DEFAULT_PHASE, INITIAL_PHASE);
+        ServerLifecycleEvents.SERVER_STARTING.register(INITIAL_PHASE, this::onEnable);
         ServerLifecycleEvents.SERVER_STOPPING.register(this::onDisable);
     }
 

--- a/fabric/src/main/java/net/william278/huskclaims/hook/FabricHuskHomesHook.java
+++ b/fabric/src/main/java/net/william278/huskclaims/hook/FabricHuskHomesHook.java
@@ -19,11 +19,15 @@
 
 package net.william278.huskclaims.hook;
 
+import net.minecraft.util.ActionResult;
 import net.william278.huskclaims.HuskClaims;
 import net.william278.huskclaims.position.Position;
 import net.william278.huskclaims.position.World;
 import net.william278.huskclaims.user.OnlineUser;
 import net.william278.huskhomes.api.FabricHuskHomesAPI;
+import net.william278.huskhomes.event.HomeCreateCallback;
+import net.william278.huskhomes.event.HomeEditCallback;
+import net.william278.huskhomes.user.FabricUser;
 import org.jetbrains.annotations.NotNull;
 
 @PluginHook(
@@ -43,21 +47,21 @@ public class FabricHuskHomesHook extends HuskHomesHook {
         super.load();
         huskHomes = FabricHuskHomesAPI.getInstance();
 
-//        HomeCreateCallback.EVENT.register((event) -> {
-//            if (!(event.getCreator() instanceof FabricUser player)) {
-//                return ActionResult.PASS;
-//            }
-//            return cancelSetHomeAt(getPlugin().getOnlineUser(player.getUuid()),
-//                    Adapter.adapt(event.getPosition())) ? ActionResult.FAIL : ActionResult.PASS;
-//        });
-//        HomeEditCallback.EVENT.register((event) -> {
-//            if (!(event.getEditor() instanceof FabricUser player)
-//                    || !hasMoved(event.getOriginalHome(), event.getHome())) {
-//                return ActionResult.PASS;
-//            }
-//            return cancelSetHomeAt(getPlugin().getOnlineUser(player.getUuid()),
-//                    Adapter.adapt(event.getHome())) ? ActionResult.FAIL : ActionResult.PASS;
-//        });
+        HomeCreateCallback.EVENT.register((event) -> {
+            if (!(event.getCreator() instanceof FabricUser player)) {
+                return ActionResult.PASS;
+            }
+            return cancelSetHomeAt(getPlugin().getOnlineUser(player.getUuid()),
+                    Adapter.adapt(event.getPosition())) ? ActionResult.FAIL : ActionResult.PASS;
+        });
+        HomeEditCallback.EVENT.register((event) -> {
+            if (!(event.getEditor() instanceof FabricUser player)
+                    || !hasMoved(event.getOriginalHome(), event.getHome())) {
+                return ActionResult.PASS;
+            }
+            return cancelSetHomeAt(getPlugin().getOnlineUser(player.getUuid()),
+                    Adapter.adapt(event.getHome())) ? ActionResult.FAIL : ActionResult.PASS;
+        });
     }
 
     @Override


### PR DESCRIPTION
- The first commit fixes: 

```
[18:25:01 ERROR] [Server thread]: [HuskClaims] Failed to register the HuskHomes hook
net.william278.huskhomes.api.BaseHuskHomesAPI$NotRegisteredException: Could not access the HuskHomes API as it has not yet been registered. This could be because:
1) HuskHomes has failed to enable successfully
2) Your plugin isn't set to load after HuskHomes has
   (Check if it set as a (soft)depend in plugin.yml or to load: BEFORE in paper-plugin.yml?)
3) You are attempting to access HuskHomes on plugin construction/before your plugin has enabled.
        at knot/net.william278.huskhomes.api.BaseHuskHomesAPI.getInstance(BaseHuskHomesAPI.java:950) ~[huskhomes_common-4.9-c0f0fbd5c058ff03.jar:?]
        at knot/net.william278.huskhomes.api.FabricHuskHomesAPI.getInstance(FabricHuskHomesAPI.java:68) ~[HuskHomes-Fabric-4.9+mc.1.21.1.jar:?]
        at knot/net.william278.huskclaims.hook.FabricHuskHomesHook.load(FabricHuskHomesHook.java:48) ~[HuskClaims-Fabric-1.5-6140863-indev+mc.1.21.1.jar:?]
        at knot/net.william278.huskclaims.hook.HookProvider.lambda$registerHooks$7(HookProvider.java:83) ~[huskclaims_common-1.5-6140863-indev-aed9d1574efce3f1.jar:?]
        at java.base/java.util.Collection.removeIf(Collection.java:583) ~[?:?]
        at knot/net.william278.huskclaims.hook.HookProvider.registerHooks(HookProvider.java:78) ~[huskclaims_common-1.5-6140863-indev-aed9d1574efce3f1.jar:?]
        at knot/net.william278.huskclaims.HuskClaims.enable(HuskClaims.java:94) ~[huskclaims_common-1.5-6140863-indev-aed9d1574efce3f1.jar:?]
        at knot/net.william278.huskclaims.FabricHuskClaims.onEnable(FabricHuskClaims.java:170) ~[HuskClaims-Fabric-1.5-6140863-indev+mc.1.21.1.jar:?]
        at knot/net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.lambda$static$0(ServerLifecycleEvents.java:38) ~[fabric-lifecycle-events-v1-2.5.0+01d9a51c19-d79236b315b9dd73.jar:?]
        at knot/net.minecraft.server.MinecraftServer.handler$zlh000$fabric-lifecycle-events-v1$beforeSetupServer(MinecraftServer.java:3638) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:664) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:281) ~[server-intermediary.jar:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```

- The second commit adds the use of HuskHomes events