### PR TITLE
Fixed permissions for usergroup and claimblocks commands

### DIFF
--- a/common/src/main/java/net/william278/huskclaims/command/ClaimBlocksCommand.java
+++ b/common/src/main/java/net/william278/huskclaims/command/ClaimBlocksCommand.java
@@ -64,7 +64,7 @@ public class ClaimBlocksCommand extends Command implements UserListTabCompletabl
 
         final User user = optionalUser.get();
         if (!option.hasPermission(executor, this) || (!hasPermission(executor, "other")
-                && (executor instanceof OnlineUser other && !other.equals(user)))) {
+                && (executor instanceof OnlineUser other && !other.equals(user))) && option == ClaimBlockOption.SHOW) {
             plugin.getLocales().getLocale("error_no_permission")
                     .ifPresent(executor::sendMessage);
             return;

--- a/common/src/main/java/net/william278/huskclaims/command/UserGroupsCommand.java
+++ b/common/src/main/java/net/william278/huskclaims/command/UserGroupsCommand.java
@@ -38,7 +38,7 @@ public class UserGroupsCommand extends OnlineUserCommand implements TabCompletab
 
     protected UserGroupsCommand(@NotNull HuskClaims plugin) {
         super(
-                List.of("group", "usergroup"),
+                List.of("usergroup", "group"),
                 "[name] [<add|remove> <user(s)>|delete|list] ",
                 plugin
         );


### PR DESCRIPTION
According to the [documentation](https://william278.net/docs/huskclaims/commands), the permission for the usergroup command should be "huskclaims.command.usergroup" not "huskclaims.command.group".

In addition, the claimblocks subcommands gift|add|remove|set should not require the permission "huskclaims.command.claimblocks.other".