### PR TITLE
Some changes on `maximum_claim_blocks`

### DIFF
--- a/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitGriefPreventionImporter.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitGriefPreventionImporter.java
@@ -126,7 +126,6 @@ public class BukkitGriefPreventionImporter extends Importer {
     }
 
     private int importUsers() {
-        //
         final int totalUsers = getTotalUsers();
         final int totalPages = (int) Math.ceil(totalUsers / (double) USERS_PER_PAGE);
         final List<CompletableFuture<List<GriefPreventionUser>>> userPages = IntStream.rangeClosed(1, totalPages)
@@ -173,6 +172,7 @@ public class BukkitGriefPreventionImporter extends Importer {
                     })
                     .sum();
             user.claimBlocks = Math.max(0, user.claimBlocks - totalArea);
+            user.spentClaimBlocks = totalArea;
 
             saveFutures.add(CompletableFuture.runAsync(
                     () -> {
@@ -361,6 +361,7 @@ public class BukkitGriefPreventionImporter extends Importer {
                             UUID.fromString(resultSet.getString("name")),
                             resultSet.getTimestamp("lastlogin"),
                             resultSet.getInt("claimblocks"),
+                            0,
                             (BukkitHuskClaims) plugin
                     ));
                 }
@@ -408,12 +409,14 @@ public class BukkitGriefPreventionImporter extends Importer {
         private String name;
         private final Timestamp lastLogin;
         private int claimBlocks;
+        private int spentClaimBlocks;
 
         private GriefPreventionUser(@NotNull UUID uuid, @NotNull Timestamp lastLogin, int claimBlocks,
-                                    @NotNull BukkitHuskClaims plugin) {
+                                    int spentClaimBlocks, @NotNull BukkitHuskClaims plugin) {
             this.uuid = uuid;
             this.lastLogin = lastLogin;
             this.claimBlocks = claimBlocks;
+            this.spentClaimBlocks = spentClaimBlocks;
 
             final OfflinePlayer player = plugin.getServer().getOfflinePlayer(uuid);
             if (player.hasPlayedBefore()) {
@@ -437,7 +440,7 @@ public class BukkitGriefPreventionImporter extends Importer {
 
         @NotNull
         private SavedUser toSavedUser() {
-            return SavedUser.createImported(toUser(), getLastLogin(), claimBlocks, 0);
+            return SavedUser.createImported(toUser(), getLastLogin(), claimBlocks, spentClaimBlocks);
         }
 
     }

--- a/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitGriefPreventionImporter.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitGriefPreventionImporter.java
@@ -126,6 +126,7 @@ public class BukkitGriefPreventionImporter extends Importer {
     }
 
     private int importUsers() {
+        //
         final int totalUsers = getTotalUsers();
         final int totalPages = (int) Math.ceil(totalUsers / (double) USERS_PER_PAGE);
         final List<CompletableFuture<List<GriefPreventionUser>>> userPages = IntStream.rangeClosed(1, totalPages)
@@ -436,7 +437,7 @@ public class BukkitGriefPreventionImporter extends Importer {
 
         @NotNull
         private SavedUser toSavedUser() {
-            return SavedUser.createImported(toUser(), getLastLogin(), claimBlocks);
+            return SavedUser.createImported(toUser(), getLastLogin(), claimBlocks, 0);
         }
 
     }

--- a/common/src/main/java/net/william278/huskclaims/claim/ClaimPruner.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/ClaimPruner.java
@@ -112,11 +112,18 @@ public interface ClaimPruner {
     // Refunds claim blocks based on a user map of blocks to refund
     @Blocking
     private void refundPrunedBlocks(@NotNull Map<User, Long> blocksToRefund) {
-        blocksToRefund.forEach((user, blocks) -> getPlugin().editClaimBlocks(
-                user,
-                ClaimBlockSource.CLAIMS_DELETED_PRUNED,
-                (b -> b + blocks)
-        ));
+        blocksToRefund.forEach((user, blocks) -> {
+            getPlugin().editClaimBlocks(
+                    user,
+                    ClaimBlockSource.CLAIMS_DELETED_PRUNED,
+                    (b -> b + blocks)
+            );
+            getPlugin().editSpentClaimBlocks(
+                    user,
+                    ClaimBlockSource.CLAIMS_DELETED_PRUNED,
+                    (b -> b - blocks)
+            );
+        });
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/huskclaims/command/ClaimBlocksCommand.java
+++ b/common/src/main/java/net/william278/huskclaims/command/ClaimBlocksCommand.java
@@ -91,7 +91,7 @@ public class ClaimBlocksCommand extends Command implements UserListTabCompletabl
         // Calculate the user's claim block totals
         long started = settings.getStartingClaimBlocks();
         long available = Math.max(0, plugin.getClaimBlocks(user.getUuid()));
-        long spent = Math.max(0, claims.stream().map(ServerWorldClaim::getSurfaceArea).reduce(0L, Long::sum));
+        long spent = Math.max(0, plugin.getSpentClaimBlocks(user.getUuid()));
         long earned = (available + spent) - started;
         long accrued = started + earned;
 

--- a/common/src/main/java/net/william278/huskclaims/command/UnClaimAllCommand.java
+++ b/common/src/main/java/net/william278/huskclaims/command/UnClaimAllCommand.java
@@ -130,6 +130,7 @@ public class UnClaimAllCommand extends OnlineUserCommand implements UserListTabC
             long reclaimedBlocks = claims.stream().mapToLong(ServerWorldClaim::getSurfaceArea).sum();
             plugin.deleteAllClaims(executor, user);
             plugin.editClaimBlocks(user, ClaimBlocksManager.ClaimBlockSource.CLAIM_DELETED, (blocks) -> blocks + reclaimedBlocks);
+            plugin.editSpentClaimBlocks(user, ClaimBlocksManager.ClaimBlockSource.CLAIM_DELETED, (blocks) -> 0L);
             plugin.getLocales().getLocale("delete_all_claims", user.getName(), Integer.toString(claims.size()),
                     Long.toString(reclaimedBlocks)).ifPresent(executor::sendMessage);
             plugin.getHighlighter(executor).stopHighlighting(executor);

--- a/common/src/main/java/net/william278/huskclaims/config/Settings.java
+++ b/common/src/main/java/net/william278/huskclaims/config/Settings.java
@@ -209,7 +209,8 @@ public final class Settings {
                 "Override with the \"huskclaims.hourly_blocks.(amount)\" permission"})
         private long hourlyClaimBlocks = 100;
 
-        @Comment("The maximum number of claim blocks a user can have.")
+        @Comment({"The maximum number of claim blocks a user can have.",
+                "Override with the \"huskclaims.max_claim_blocks.(amount)\" permission"})
         private long maximumClaimBlocks = 9999999;
 
         @Comment({"The maximum amount of land, in claim blocks, that can be affected at once by /claim, /extendclaim,",

--- a/common/src/main/java/net/william278/huskclaims/user/ClaimBlocksManager.java
+++ b/common/src/main/java/net/william278/huskclaims/user/ClaimBlocksManager.java
@@ -40,6 +40,7 @@ public interface ClaimBlocksManager {
 
     // Permission to grant hourly claim blocks
     String HOURLY_BLOCKS_PERMISSION = "huskclaims.hourly_blocks.";
+    String MAX_CLAIM_BLOCKS_PERMISSION = "huskclaims.max_claim_blocks.";
 
     Optional<SavedUser> getCachedSavedUser(@NotNull UUID uuid);
 
@@ -69,6 +70,9 @@ public interface ClaimBlocksManager {
                                  @NotNull Function<Long, Long> consumer, @Nullable Consumer<Long> callback) {
         // Determine max claim blocks
         long maxClaimBlocks = getPlugin().getSettings().getClaims().getMaximumClaimBlocks();
+        if (user instanceof OnlineUser onlineUser) {
+            maxClaimBlocks = onlineUser.getNumericalPermission(MAX_CLAIM_BLOCKS_PERMISSION).orElse(maxClaimBlocks);
+        }
         if (maxClaimBlocks < 0) {
             maxClaimBlocks = Long.MAX_VALUE;
         }

--- a/common/src/main/java/net/william278/huskclaims/user/SavedUser.java
+++ b/common/src/main/java/net/william278/huskclaims/user/SavedUser.java
@@ -47,12 +47,15 @@ public class SavedUser {
     @Range(from = 0, to = MAX_CLAIM_BLOCKS)
     private long claimBlocks;
     @Setter
+    @Range(from = 0, to = MAX_CLAIM_BLOCKS)
+    private long spentClaimBlocks;
+    @Setter
     @Deprecated(since = "1.4.5", forRemoval = true)
     private int hoursPlayed;
 
     public SavedUser(@NotNull User user, @NotNull Preferences preferences,
-                     @NotNull OffsetDateTime lastLogin, long claimBlocks) {
-        this(user, preferences, lastLogin, claimBlocks, 0);
+                     @NotNull OffsetDateTime lastLogin, long claimBlocks, long spentClaimBlocks) {
+        this(user, preferences, lastLogin, claimBlocks, spentClaimBlocks, 0);
     }
 
     public long getDaysSinceLastLogin() {
@@ -73,7 +76,8 @@ public class SavedUser {
                 user,
                 Preferences.DEFAULTS,
                 OffsetDateTime.now(),
-                plugin.getSettings().getClaims().getStartingClaimBlocks()
+                plugin.getSettings().getClaims().getStartingClaimBlocks(),
+                0
         );
     }
 
@@ -87,12 +91,13 @@ public class SavedUser {
      * @since 1.0.3
      */
     @NotNull
-    public static SavedUser createImported(@NotNull User user, @NotNull OffsetDateTime lastLogin, int claimBlocks) {
+    public static SavedUser createImported(@NotNull User user, @NotNull OffsetDateTime lastLogin, int claimBlocks, int spentClaimBlocks) {
         return new SavedUser(
                 user,
                 Preferences.IMPORTED,
                 lastLogin,
-                claimBlocks
+                claimBlocks,
+                spentClaimBlocks
         );
     }
 

--- a/common/src/main/resources/database/mariadb_schema.sql
+++ b/common/src/main/resources/database/mariadb_schema.sql
@@ -15,11 +15,12 @@ CREATE TABLE IF NOT EXISTS `%meta_data%`
 # Create the users table if it does not exist
 CREATE TABLE IF NOT EXISTS `%user_data%`
 (
-    `uuid`         char(36)    NOT NULL UNIQUE,
-    `username`     varchar(16) NOT NULL,
-    `last_login`   timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `claim_blocks` bigint      NOT NULL DEFAULT 0,
-    `preferences`  longblob    NOT NULL,
+    `uuid`               char(36)    NOT NULL UNIQUE,
+    `username`           varchar(16) NOT NULL,
+    `last_login`         timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `claim_blocks`       bigint      NOT NULL DEFAULT 0,
+    `preferences`        longblob    NOT NULL,
+    `spent_claim_blocks` bigint      NOT NULL DEFAULT 0,
 
     PRIMARY KEY (`uuid`)
 ) ENGINE = InnoDB

--- a/common/src/main/resources/database/migrations/3-mariadb-add_spent_claim_blocks_column.sql
+++ b/common/src/main/resources/database/migrations/3-mariadb-add_spent_claim_blocks_column.sql
@@ -1,0 +1,2 @@
+# Add the spent claim blocks column
+ALTER TABLE `%user_data%` ADD COLUMN `spent_claim_blocks`;

--- a/common/src/main/resources/database/migrations/3-mysql-add_spent_claim_blocks_column.sql
+++ b/common/src/main/resources/database/migrations/3-mysql-add_spent_claim_blocks_column.sql
@@ -1,0 +1,2 @@
+# Add the spent claim blocks column
+ALTER TABLE `%user_data%` ADD COLUMN `spent_claim_blocks`;

--- a/common/src/main/resources/database/migrations/3-sqlite-add_spent_claim_blocks_column.sql
+++ b/common/src/main/resources/database/migrations/3-sqlite-add_spent_claim_blocks_column.sql
@@ -1,0 +1,2 @@
+# Add the spent claim blocks column
+ALTER TABLE `%user_data%` ADD COLUMN `spent_claim_blocks`;

--- a/common/src/main/resources/database/mysql_schema.sql
+++ b/common/src/main/resources/database/mysql_schema.sql
@@ -14,11 +14,12 @@ CREATE TABLE IF NOT EXISTS `%meta_data%`
 # Create the users table if it does not exist
 CREATE TABLE IF NOT EXISTS `%user_data%`
 (
-    `uuid`         char(36)    NOT NULL UNIQUE,
-    `username`     varchar(16) NOT NULL,
-    `last_login`   timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `claim_blocks` bigint      NOT NULL DEFAULT 0,
-    `preferences`  longblob    NOT NULL,
+    `uuid`               char(36)      NOT NULL UNIQUE,
+    `username`           varchar(16)   NOT NULL,
+    `last_login`         timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `claim_blocks`       bigint        NOT NULL DEFAULT 0,
+    `preferences`        longblob      NOT NULL,
+    `spent_claim_blocks` bigint        NOT NULL DEFAULT 0,
 
     PRIMARY KEY (`uuid`)
 ) CHARACTER SET utf8

--- a/common/src/main/resources/database/sqlite_schema.sql
+++ b/common/src/main/resources/database/sqlite_schema.sql
@@ -7,11 +7,12 @@ CREATE TABLE IF NOT EXISTS `%meta_data%`
 -- Create the users table if it does not exist
 CREATE TABLE IF NOT EXISTS `%user_data%`
 (
-    `uuid`         char(36)    NOT NULL UNIQUE,
-    `username`     varchar(16) NOT NULL,
-    `last_login`   timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `claim_blocks` bigint      NOT NULL DEFAULT 0,
-    `preferences`  longblob    NOT NULL,
+    `uuid`               char(36)      NOT NULL UNIQUE,
+    `username`           varchar(16)   NOT NULL,
+    `last_login`         timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `claim_blocks`       bigint        NOT NULL DEFAULT 0,
+    `preferences`        longblob      NOT NULL,
+    `spent_claim_blocks` bigint        NOT NULL DEFAULT 0,
 
     PRIMARY KEY (`uuid`)
 );


### PR DESCRIPTION
As the title suggests, a permission has been added to control it (`huskhomes.max_claim_blocks.(amount)`), and make the variant of maximum_claim_blocks applying to total spent+unspent claim blocks. Associated with issues #378, #270 