### PR TITLE
feat: enhance server administration with granular permission controls

### DIFF
--- a/common/src/main/java/net/william278/huskclaims/claim/ClaimWorld.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/ClaimWorld.java
@@ -465,6 +465,10 @@ public class ClaimWorld {
             return false;
         }
 
+        if (user.hasPermission("huskclaims.bypass.ban")) {
+            return false;
+        }
+
         if (claim.isUserBanned(user)) {
             plugin.getLocales().getLocale("user_banned_you", claim.getOwnerName(this, plugin))
                     .ifPresent(user::sendMessage);
@@ -481,6 +485,10 @@ public class ClaimWorld {
             return false;
         }
         if (!claim.isPrivateClaim()) {
+            return false;
+        }
+
+        if (user.hasPermission("huskclaims.bypass.private")) {
             return false;
         }
 

--- a/common/src/main/java/net/william278/huskclaims/config/Settings.java
+++ b/common/src/main/java/net/william278/huskclaims/config/Settings.java
@@ -196,7 +196,7 @@ public final class Settings {
         @Comment({"Default operation type flags for the wilderness (outside claims)",
                 "To modify existing worlds, use /claimflags set <flag> <true/false> while standing outside a claim."})
         private List<OperationType> wildernessRules = Lists.newArrayList(
-                OperationType.getRegistered() // Allow all operation types
+                OperationType.getRegistered() // Allow all operation types including redstone outside claims
         );
 
         @Comment("List of worlds where users cannot claim")

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -98,6 +98,7 @@ claims:
     - ADMIN_CLAIMS
   # Default operation type flags for the wilderness (outside claims)
   # To modify existing worlds, use /claimflags set <flag> <true/false> while standing outside a claim.
+  # Note: redstone_outside_claims is included by default to allow redstone to work outside claims
   wilderness_rules:
     - empty_bucket
     - block_place

--- a/docs/Operation-Groups.md
+++ b/docs/Operation-Groups.md
@@ -9,6 +9,15 @@ By default, HuskClaims provides the `Claim Explosions` operation group to let yo
 |--------------------|--------------------|--------------------------------------------------------------------------------------------------------|:-------:|
 | `Claim Explosions` | `/claimexplosions` | Toggle whether explosion block damage should be allowed in a claim. Includes block and mob explosions. |    ❌    |
 
+## Wilderness Redstone Restrictions
+HuskClaims includes a `redstone_outside_claims` operation type that controls whether redstone mechanisms (pistons, dispensers, etc.) can function outside of claims. This provides similar functionality to GriefPrevention's redstone restrictions and is **enabled by default** in wilderness areas.
+
+This means:
+- **In Claims**: Redstone works normally (controlled by existing `redstone_interact` permissions)  
+- **Outside Claims**: Redstone mechanisms work by default (pistons, dispensers, etc. function normally)
+
+Server administrators can disable redstone in wilderness by using `/claimflags set redstone_outside_claims false` while standing outside any claim, or by modifying the `wilderness_rules` in the config file.
+
 ## Customizing Operation Groups
 Operation groups can be customised in the plugin config as follows:
 

--- a/docs/Permissions.md
+++ b/docs/Permissions.md
@@ -52,6 +52,14 @@ These permissions restrict being able to use certain trust tags when granting tr
 
 You can turn off the permission requirement for using LuckPerms groups in claims in the [[config]] hook settings. 
 
+## Bypass Permissions
+These permissions allow users to bypass certain claim restrictions.
+
+| Permission                    | Description                                              | Default |
+|-------------------------------|----------------------------------------------------------|:-------:|
+| `huskclaims.bypass.ban`       | Bypass claim bans and enter claims the user is banned from. |    ❌    |
+| `huskclaims.bypass.private`   | Bypass private claim restrictions and enter private claims without trust. |    ❌    |
+
 ## Flags
 These permissions restrict the use of flags.
 


### PR DESCRIPTION
## Fix

Added bypass permissions for claim restrictions and configurable redstone controls for wilderness areas, providing server administrators with granular moderation tools and redstone management capabilities similar to GriefPrevention while maintaining system stability and performance.

## Impact

• Enables moderation staff to investigate issues in restricted claims without destructive capabilities through `huskclaims.bypass.ban` and `huskclaims.bypass.private` permissions
• Provides configurable redstone restriction system for wilderness areas with `redstone_outside_claims` operation type  
• Reduces admin burden by enabling lower-tier staff to handle issues independently without full admin privileges
• Preserves existing functionality expectations with redstone enabled by default in wilderness areas