### PR TITLE
Retain parity by utilizing ConcurrentMap and not map for `Maps.newConcurrentMap`

### DIFF
--- a/bukkit/src/main/java/net/william278/huskclaims/BukkitHuskClaims.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/BukkitHuskClaims.java
@@ -88,8 +88,8 @@ public class BukkitHuskClaims extends JavaPlugin implements HuskClaims, BukkitTa
     private Toilet toilet;
     private final Gson gson = getGsonBuilder().create();
     private final Set<TrustTag> trustTags = ConcurrentHashMap.newKeySet();
-    private final Map<UUID, List<DroppedItem>> markedDrops = Maps.newConcurrentMap();
-    private final Map<UUID, Set<GroundStack>> trackedItems = Maps.newConcurrentMap();
+    private final ConcurrentMap<UUID, List<DroppedItem>> markedDrops = Maps.newConcurrentMap();
+    private final ConcurrentMap<UUID, Set<GroundStack>> trackedItems = Maps.newConcurrentMap();
     private final ConcurrentMap<String, List<User>> globalUserList = Maps.newConcurrentMap();
     private final ConcurrentMap<UUID, ClaimSelection> claimSelections = Maps.newConcurrentMap();
     private final ConcurrentMap<UUID, OnlineUser> onlineUserMap = Maps.newConcurrentMap();


### PR DESCRIPTION
One minor "mistake" I made when merging in Folia was that I retained the use of a standard Map instead of a ConcurrentMap. Although this may not be absolutely integral, other similar methods utilize the same function, meaning it'd make the most sense to replicate them.