### PR TITLE
qol: hide vanished players from command tab completion

### DIFF
--- a/bukkit/src/main/java/net/william278/huskclaims/user/BukkitUser.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/user/BukkitUser.java
@@ -127,4 +127,12 @@ public class BukkitUser extends OnlineUser {
         PaperLib.teleportAsync(bukkitPlayer, BukkitHuskClaims.Adapter.adapt(position));
     }
 
+    @Override
+    public boolean canSee(@NotNull OnlineUser other) {
+        if (other instanceof BukkitUser bukkitOther) {
+            return bukkitPlayer.canSee(bukkitOther.getBukkitPlayer());
+        }
+        return true;
+    }
+
 }

--- a/common/src/main/java/net/william278/huskclaims/command/UserListTabCompletable.java
+++ b/common/src/main/java/net/william278/huskclaims/command/UserListTabCompletable.java
@@ -21,6 +21,7 @@ package net.william278.huskclaims.command;
 
 import net.william278.huskclaims.HuskClaims;
 import net.william278.huskclaims.user.CommandUser;
+import net.william278.huskclaims.user.OnlineUser;
 import net.william278.huskclaims.user.User;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -32,7 +33,20 @@ public interface UserListTabCompletable extends TabCompletable {
     @Override
     @Nullable
     default List<String> suggest(@NotNull CommandUser user, @NotNull String[] args) {
-        return getPlugin().getUserList().stream().map(User::getName).toList();
+        if (user instanceof OnlineUser onlineUser) {
+            return getPlugin().getUserList().stream()
+                    .filter(userInList -> {
+                        if (userInList instanceof OnlineUser onlineUserInList) {
+                            return onlineUser.canSee(onlineUserInList);
+                        }
+                        return true;
+                    })
+                    .map(User::getName)
+                    .toList();
+        }
+        return getPlugin().getUserList().stream()
+                .map(User::getName)
+                .toList();
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/huskclaims/user/OnlineUser.java
+++ b/common/src/main/java/net/william278/huskclaims/user/OnlineUser.java
@@ -101,5 +101,12 @@ public abstract class OnlineUser extends User implements OperationUser, CommandU
 
     public abstract void teleport(@NotNull Position position, boolean instant);
 
+    /**
+     * Returns whether this user can see the specified user
+     *
+     * @param other The other user to check visibility for
+     * @return Whether this user can see the other user
+     */
+    public abstract boolean canSee(@NotNull OnlineUser other);
 
 }

--- a/fabric/src/main/java/net/william278/huskclaims/user/FabricUser.java
+++ b/fabric/src/main/java/net/william278/huskclaims/user/FabricUser.java
@@ -143,4 +143,12 @@ public class FabricUser extends OnlineUser {
         return fabricPlayer;
     }
 
+    @Override
+    public boolean canSee(@NotNull OnlineUser other) {
+        if (other instanceof FabricUser fabricOther) {
+            return fabricPlayer.getServer().getPlayerManager().getPlayer(fabricOther.getFabricPlayer().getUuid()) != null;
+        }
+        return true;
+    }
+
 }


### PR DESCRIPTION
Does what it says on the tin.. 

Preventing people from tab completing names when the user is vanished/cannot be seen. 
For practically all cases, this would make the most sense since under all enviroments using huskclaims as most cases a vanished player will be a staff member trying to remain hidden. 

<img width="412" height="584" alt="image" src="https://github.com/user-attachments/assets/c7b4c0ae-9e0b-49a1-9025-de1665599742" />

This is mainly inspired by this report made by an internal staff member on one of my servers. 