### PR TITLE
fix: owners could not build if #public had a non-build trust allowed

### DIFF
--- a/common/src/main/java/net/william278/huskclaims/claim/Claim.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/Claim.java
@@ -518,9 +518,13 @@ public class Claim implements Highlightable {
      * @since 1.0
      */
     public boolean isOperationAllowed(@NotNull Operation operation, @NotNull HuskClaims plugin) {
+        if(owner != null && operation.getUser()
+                .filter(user -> owner.equals(user.getUuid()))
+                .map(u -> plugin.allowedOwnerOperations().contains(operation.getType()))
+                .orElse(false)) return true;
+
         // If the operation is explicitly allowed, return it
         return defaultFlags.contains(operation.getType())
-
                 // Or, if the user is the owner, return true
                 || (owner != null && operation.getUser()
                 .filter(user -> owner.equals(user.getUuid()))


### PR DESCRIPTION
For some reason, owners weren't allowed to place vanilla blocks on top of Nexo blocks (at this point I'm drawn to think it's on top of all block entities, as Nexo blocks are noteblocks) if #public had a non-build trust assigned.

Repeating the owner check fixes this, as the workaround on our server was to set the owner also as co-owner.
It isn't the cleanest fix, but it's a workaround until the reason is figured out.