### PR TITLE
fix: hourly blocks permission filtering 

### DIFF
--- a/bukkit/src/main/java/net/william278/huskclaims/user/BukkitUser.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/user/BukkitUser.java
@@ -94,7 +94,7 @@ public class BukkitUser extends OnlineUser {
     @Override
     public Optional<Long> getNumericalPermission(@NotNull String prefix) {
         return bukkitPlayer.getEffectivePermissions().stream()
-                .filter(perm -> perm.getPermission().startsWith(prefix))
+                .filter(perm -> perm.getPermission().startsWith(prefix) && perm.getValue())
                 .map(perm -> perm.getPermission().substring(prefix.length()))
                 .map(value -> {
                     try {
@@ -103,8 +103,8 @@ public class BukkitUser extends OnlineUser {
                         return null;
                     }
                 })
-                .filter(Objects::nonNull).sorted()
-                .findFirst();
+                .filter(Objects::nonNull)
+                .max(Long::compareTo);
     }
 
     @Override

--- a/fabric/src/main/java/net/william278/huskclaims/user/FabricUser.java
+++ b/fabric/src/main/java/net/william278/huskclaims/user/FabricUser.java
@@ -110,7 +110,7 @@ public class FabricUser extends OnlineUser {
                 permissions.add(l);
             }
         }
-        return permissions.stream().sorted().findFirst();
+        return permissions.stream().max(Long::compareTo);
     }
 
     @Override


### PR DESCRIPTION
Fix getNumericalPermission returning minimum instead of maximum value

Changed from `.sorted().findFirst()` to `.max(Long::compareTo)` so users with multiple numerical permissions (e.g., `huskclaims.hourly_blocks.100` and `huskclaims.hourly_blocks.1000`) get the highest value instead of the lowest.

Fixes all cases of servers working with inherited permissions.
