### PR TITLE
fix: extendclaim showing correctly total blocks needed to expansion instead of missing blocks

### DIFF
--- a/common/src/main/java/net/william278/huskclaims/claim/ClaimEditor.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/ClaimEditor.java
@@ -179,9 +179,10 @@ public interface ClaimEditor {
             }
 
             // Check claim blocks
-            if (getPlugin().getCachedClaimBlocks(user) < neededBlocks) {
+            final long userBlocks = getPlugin().getCachedClaimBlocks(user);
+            if (userBlocks < neededBlocks) {
                 getPlugin().getLocales().getLocale("error_not_enough_claim_blocks",
-                        Long.toString(neededBlocks)).ifPresent(user::sendMessage);
+                        Long.toString(neededBlocks - userBlocks)).ifPresent(user::sendMessage);
                 return;
             }
         }


### PR DESCRIPTION
Fixed a bug in the /extendclaim command where the error message was displaying the total number of claim blocks required for expansion instead of only showing how many blocks the player is missing.

The error message now correctly calculates and displays the difference between needed blocks and the player's current blocks (neededBlocks - userBlocks), making it consistent with the /claim command behavior.

Changes:
- Store userBlocks in a variable before validation
- Calculate missing blocks (neededBlocks - userBlocks) for error message
- Ensures players see only what they're missing, not the total expansion cost