### PR TITLE
feat: case-insensitive username lookup for commands

### DIFF
--- a/common/src/main/java/net/william278/huskclaims/database/MongoDbDatabase.java
+++ b/common/src/main/java/net/william278/huskclaims/database/MongoDbDatabase.java
@@ -28,6 +28,8 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
+
+import java.util.regex.Pattern;
 import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.Updates;
 import net.william278.huskclaims.HuskClaims;
@@ -226,7 +228,8 @@ public class MongoDbDatabase extends Database {
     @Override
     public Optional<SavedUser> getUser(@NotNull String username) {
         try {
-            final Document document = userCollection.find(Filters.eq("username", username)).first();
+            final Document document = userCollection.find(
+                    Filters.regex("username", Pattern.compile("^" + Pattern.quote(username) + "$", Pattern.CASE_INSENSITIVE))).first();
             if (document != null) {
                 return Optional.of(documentToSavedUser(document));
             }

--- a/common/src/main/java/net/william278/huskclaims/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/huskclaims/database/MySqlDatabase.java
@@ -246,7 +246,7 @@ public class MySqlDatabase extends Database {
             try (PreparedStatement statement = connection.prepareStatement(format("""
                     SELECT `uuid`, `username`, `last_login`, `claim_blocks`, `preferences`, `spent_claim_blocks`
                     FROM `%user_data%`
-                    WHERE `username` = ?"""))) {
+                    WHERE LOWER(`username`) = LOWER(?)"""))) {
                 statement.setString(1, username);
                 final ResultSet resultSet = statement.executeQuery();
                 if (resultSet.next()) {

--- a/common/src/main/java/net/william278/huskclaims/database/SqLiteDatabase.java
+++ b/common/src/main/java/net/william278/huskclaims/database/SqLiteDatabase.java
@@ -234,7 +234,7 @@ public class SqLiteDatabase extends Database {
         try (PreparedStatement statement = getConnection().prepareStatement(format("""
                 SELECT `uuid`, `username`, `last_login`, `claim_blocks`, json(`preferences`) AS preferences, `spent_claim_blocks`
                 FROM `%user_data%`
-                WHERE `username` = ?"""))) {
+                WHERE LOWER(`username`) = LOWER(?)"""))) {
             statement.setString(1, username);
             final ResultSet resultSet = statement.executeQuery();
             if (resultSet.next()) {


### PR DESCRIPTION
Username lookups now use LOWER() in SQL and a case-insensitive regex in MongoDB so commands resolve users regardless of casing.