### PR TITLE
Fix /transferclaim always requiring "other" permission

### DIFF
--- a/common/src/main/java/net/william278/huskclaims/command/TransferClaimCommand.java
+++ b/common/src/main/java/net/william278/huskclaims/command/TransferClaimCommand.java
@@ -65,7 +65,7 @@ public class TransferClaimCommand extends InClaimOwnerCommand implements UserLis
                                @NotNull ClaimWorld world, @NotNull Claim claim) {
         // Ensure the user has permission to transfer the claim
         if ((claim.getOwner().isEmpty() && !ClaimingMode.ADMIN_CLAIMS.canUse(executor)) || (claim.getOwner().isPresent()
-                && claim.getOwner().get().equals(executor.getUuid()) && !hasPermission(executor, "other"))) {
+                && !claim.getOwner().get().equals(executor.getUuid()) && !hasPermission(executor, "other"))) {
             plugin.getLocales().getLocale("no_transfer_permission")
                     .ifPresent(executor::sendMessage);
             return;


### PR DESCRIPTION
`/transferclaim` was requiring the other permission even when the executor owned the claim. This was caused by missing `!` in the code.

## Before the fix
`executor owns the claim` -> `check other permission`

## After the fix
`executor doesn't own the claim` -> `check other permission`