### PR TITLE
Fix /transferclaim claim block dupe

### DIFF
--- a/common/src/main/java/net/william278/huskclaims/claim/ClaimEditor.java
+++ b/common/src/main/java/net/william278/huskclaims/claim/ClaimEditor.java
@@ -282,6 +282,8 @@ public interface ClaimEditor {
             });
             // Set the new owner's spent blocks so unclaim accounting works correctly
             claimWorld.getUser(newOwner.getUuid()).ifPresent(owner -> {
+                getPlugin().editClaimBlocks(
+                        owner, ClaimBlocksManager.ClaimBlockSource.CLAIM_CREATED, (blocks) -> blocks - surfaceArea);
                 getPlugin().editSpentClaimBlocks(
                         owner, ClaimBlocksManager.ClaimBlockSource.CLAIM_CREATED, (blocks) -> blocks + surfaceArea);
             });


### PR DESCRIPTION
Currently, when you transfer a claim, the new owner's claim blocks do not decrease, but their spent claimblocks are incremented. Due to this, the new owner will get free claimblocks back, when they delete the claim.

So 2 users repeating this back and forth results in an infinite amount of claimblocks for both.

This PR fixes that by properly subtracting the claimblocks from the new owners claim blocks.

### Possible side effects
Since the /transferclaim doesn't currently check if the new owner has claimblocks required for the transfer, there is a possibility that their claimblocks can go negative. So adding a some type of check here might be required, unless it's intended that claimblocks are allowed to be negative.