### PR TITLE
fix: end crystal explosions bypass explosion_damage_terrain flag

### DIFF
--- a/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitPlaceholderAPIHook.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/hook/BukkitPlaceholderAPIHook.java
@@ -105,6 +105,20 @@ public class BukkitPlaceholderAPIHook extends Hook {
         private enum Placeholder {
             CLAIM_BLOCKS((plugin, user) -> Long.toString(plugin.getCachedClaimBlocks(user))),
             CLAIM_BLOCKS_FORMATTED((plugin, user) -> String.format("%,d", plugin.getCachedClaimBlocks(user))),
+            ACCRUED_CLAIM_BLOCKS((plugin, user) -> {
+                long started = plugin.getSettings().getClaims().getStartingClaimBlocks();
+                long available = Math.max(0, plugin.getCachedClaimBlocks(user));
+                long spent = Math.max(0, plugin.getCachedSpentClaimBlocks(user));
+                long earned = (available + spent) - started;
+                return Long.toString(started + Math.max(0, earned));
+            }),
+            ACCRUED_CLAIM_BLOCKS_FORMATTED((plugin, user) -> {
+                long started = plugin.getSettings().getClaims().getStartingClaimBlocks();
+                long available = Math.max(0, plugin.getCachedClaimBlocks(user));
+                long spent = Math.max(0, plugin.getCachedSpentClaimBlocks(user));
+                long earned = (available + spent) - started;
+                return String.format("%,d", started + Math.max(0, earned));
+            }),
             CURRENT_IS_CLAIMED((plugin, user) -> formatBoolean(plugin.getClaimAt(user.getPosition()).isPresent())),
             CURRENT_CLAIM_OWNER((plugin, user) -> plugin.getClaimWorld(user.getPosition().getWorld())
                     .flatMap(world -> world.getClaimAt(user.getPosition())

--- a/bukkit/src/main/java/net/william278/huskclaims/listener/BukkitListener.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/listener/BukkitListener.java
@@ -103,11 +103,11 @@ public class BukkitListener extends BukkitOperationListener implements BukkitPet
         }
     }
 
-    // Fix: End crystals are not treated as explosion by cloplib, so their
+    // Fix: End crystals are not treated as explosion in wilderness by cloplib, so their
     // block damage bypasses explosion_damage_terrain. Override here to handle them correctly.
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
     public void onEndCrystalExplode(@NotNull EntityExplodeEvent e) {
-        if (e.getEntityType() != EntityType.END_CRYSTAL) {
+        if (!e.getEntity().getType().getKey().getKey().equals("end_crystal")) {
             return;
         }
         e.blockList().removeIf(block -> plugin.cancelOperation(

--- a/bukkit/src/main/java/net/william278/huskclaims/listener/BukkitListener.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/listener/BukkitListener.java
@@ -35,6 +35,7 @@ import org.bukkit.entity.Tameable;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.inventory.ItemStack;

--- a/bukkit/src/main/java/net/william278/huskclaims/listener/BukkitListener.java
+++ b/bukkit/src/main/java/net/william278/huskclaims/listener/BukkitListener.java
@@ -103,6 +103,21 @@ public class BukkitListener extends BukkitOperationListener implements BukkitPet
         }
     }
 
+    // Fix: End crystals are not treated as explosion by cloplib, so their
+    // block damage bypasses explosion_damage_terrain. Override here to handle them correctly.
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onEndCrystalExplode(@NotNull EntityExplodeEvent e) {
+        if (e.getEntityType() != EntityType.END_CRYSTAL) {
+            return;
+        }
+        e.blockList().removeIf(block -> plugin.cancelOperation(
+                net.william278.cloplib.operation.Operation.of(
+                        net.william278.cloplib.operation.OperationType.EXPLOSION_DAMAGE_TERRAIN,
+                        getPosition(block.getLocation())
+                )
+        ));
+    }
+        
     @EventHandler(ignoreCancelled = true)
     public void onWorldLoad(@NotNull WorldLoadEvent e) {
         plugin.runAsync(() -> {


### PR DESCRIPTION
Bug
End crystal explosions were not being blocked by the explosion_damage_terrain flag, even when it was disabled on wilderness or maybe a claim.

Root Cause
In cloplib's BukkitEntityListener, onEntityExplode only routes to handleBlockExplosion() (which checks EXPLOSION_DAMAGE_TERRAIN) if the entity is a TNTPrimed or ExplosiveMinecart. End crystals fall outside this check, so their block damage was silently processed as MONSTER_DAMAGE_TERRAIN instead — bypassing the flag entirely.